### PR TITLE
Adding State Updating and # of Tasks to LSTM and RGCN models 

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,16 +1,15 @@
 # Input files
-obs_flow: "/home/jsadler/drb_data/obs_flow_full_raw"
-obs_temp: "/home/jsadler/drb_data/obs_temp_full"
-sntemp_file: "/home/jsadler/drb_data/uncal_sntemp_input_output"
-catchment_attr: "/home/jsadler/drb_data/seg_attr_drb.feather"
-dist_matrix: "/home/jsadler/drb_data/distance_matrix.npz"
+obs_flow: "../drb-dl-model/data/in/obs_flow_subset"
+obs_temp: "../drb-dl-model/data/in/obs_temp_subset"
+sntemp_file: "../drb-dl-model/data/in/uncal_sntemp_input_output_subset"
+dist_matrix: "../drb-dl-model/data/in/distance_matrix_subset.npz"
 
 out_dir: "test_val_functionality"
 code_dir: "/home/jsadler/river-dl/river_dl"
 
 x_vars: ["seg_rain", "seg_tave_air", "seginc_swrad", "seg_length", "seginc_potet", "seg_slope", "seg_humid", "seg_elev"]
 primary_variable: "flow"
-lamb: 1
+lambdas: [100, 100]
 
 train_start_date:
   - '1985-10-01'

--- a/river_dl/RGCN.py
+++ b/river_dl/RGCN.py
@@ -16,7 +16,8 @@ class RGCN(layers.Layer):
         hidden_size, 
         A, 
         tasks=1, 
-        dropout=0,  # I propose changing this to 'recurrent_dropout' and adding another option for 'dropout' since these will map to the options for the tf LSTM layers https://www.tensorflow.org/api_docs/python/tf/keras/layers/LSTMCell ; and also https://arxiv.org/pdf/1512.05287.pdf 
+        recurrent_dropout=0,   
+        dropout=0,
         flow_in_temp=False, 
         rand_seed=None,
         return_state=False
@@ -26,7 +27,8 @@ class RGCN(layers.Layer):
         :param hidden_size: [int] the number of hidden units
         :param A: [numpy array] adjacency matrix
         :param tasks: [int] number of prediction tasks to perform - currently supports either 1 or 2 prediction tasks 
-        :param dropout: [float] value between 0 and 1 for the probability of a reccurent element to be zero  
+        :param recurrent_dropout: [float] value between 0 and 1 for the probability of a reccurent element to be zero  
+        :param dropout: [float] value between 0 and 1 for the probability of an input element to be zero  
         :param flow_in_temp: [bool] whether the flow predictions should feed
         into the temp predictions
         :param rand_seed: [int] the random seed for initialization
@@ -40,7 +42,7 @@ class RGCN(layers.Layer):
         self.return_state = return_state
 
         # set up the layer
-        self.lstm = tf.keras.layers.LSTMCell(hidden_size, recurrent_dropout=dropout)
+        self.lstm = tf.keras.layers.LSTMCell(hidden_size, recurrent_dropout=recurrent_dropout, dropout=dropout)
 
         ### set up the weights ###
         w_initializer = tf.random_normal_initializer(
@@ -234,7 +236,8 @@ class RGCNModel(tf.keras.Model):
         hidden_size, 
         A, 
         tasks=1, 
-        dropout=0, # I propose changing this to 'recurrent_dropout' and adding another option for 'dropout' since these will map to the options for the tf LSTM layers https://www.tensorflow.org/api_docs/python/tf/keras/layers/LSTMCell ; and also https://arxiv.org/pdf/1512.05287.pdf 
+        recurrent_dropout=0,  
+        dropout=0,
         flow_in_temp=False, 
         rand_seed=None,
         return_state=False
@@ -243,7 +246,8 @@ class RGCNModel(tf.keras.Model):
         :param hidden_size: [int] the number of hidden units
         :param A: [numpy array] adjacency matrix
         :param tasks: [int] number of prediction tasks to perform - currently supports either 1 or 2 prediction tasks 
-        :param dropout: [float] value between 0 and 1 for the probability of a reccurent element to be zero  
+        :param recurrent_dropout: [float] value between 0 and 1 for the probability of a reccurent element to be zero  
+        :param dropout: [float] value between 0 and 1 for the probability of an input element to be zero  
         :param flow_in_temp: [bool] whether the flow predictions should feed
         into the temp predictions
         :param rand_seed: [int] the random seed for initialization
@@ -253,18 +257,21 @@ class RGCNModel(tf.keras.Model):
         self.return_state = return_state
         self.hidden_size = hidden_size 
         self.tasks = tasks 
+        self.recurrent_dropout = recurrent_dropout
         self.dropout = dropout 
         self.rnn_layer = tf.keras.layers.LSTM(
             hidden_size, 
             return_sequences=True, 
             stateful=True,
             return_state=return_state,
-            recurrent_dropout=dropout)
+            recurrent_dropout=recurrent_dropout,
+            dropout=dropout)
             
         self.rgcn_layer = RGCN(
             hidden_size, 
             A,
             tasks,
+            recurrent_dropout
             dropout,
             flow_in_temp, 
             rand_seed,

--- a/river_dl/RGCN.py
+++ b/river_dl/RGCN.py
@@ -178,8 +178,7 @@ class RGCNModel(tf.keras.Model):
             dropout,
             rand_seed)
             
-        self.h_gr = None
-        self.c_gr = None
+        self.states = None
 
         self.dense_main = layers.Dense(1, name="dense_main")
         if self.num_tasks == 2:
@@ -190,8 +189,7 @@ class RGCNModel(tf.keras.Model):
         h_init = kwargs.get('h_init', tf.zeros([batch_size, self.hidden_size]))
         c_init = kwargs.get('c_init', tf.zeros([batch_size, self.hidden_size]))
         h_gr, c_gr = self.rgcn_layer(inputs, h_init=h_init, c_init=c_init)
-        self.h_gr = h_gr
-        self.c_gr = c_gr
+        self.states = h_gr[:, -1, :], c_gr[:, -1, :]
 
         if self.num_tasks == 1:
             main_prediction = self.dense_main(h_gr)

--- a/river_dl/RGCN.py
+++ b/river_dl/RGCN.py
@@ -247,7 +247,7 @@ class RGCNModel(tf.keras.Model):
         self.rnn_layer = tf.keras.layers.LSTM(
             hidden_size, 
             return_sequences=True, 
-            stateful=True,
+            stateful=return_state,
             return_state=return_state,
             recurrent_dropout=recurrent_dropout,
             dropout=dropout)

--- a/river_dl/RGCN.py
+++ b/river_dl/RGCN.py
@@ -16,7 +16,7 @@ class RGCN(layers.Layer):
         hidden_size, 
         A, 
         tasks=1, 
-        dropout=0, 
+        dropout=0,  # I propose changing this to 'recurrent_dropout' and adding another option for 'dropout' since these will map to the options for the tf LSTM layers https://www.tensorflow.org/api_docs/python/tf/keras/layers/LSTMCell ; and also https://arxiv.org/pdf/1512.05287.pdf 
         flow_in_temp=False, 
         rand_seed=None,
         return_state=False
@@ -25,9 +25,12 @@ class RGCN(layers.Layer):
 
         :param hidden_size: [int] the number of hidden units
         :param A: [numpy array] adjacency matrix
+        :param tasks: [int] number of prediction tasks to perform - currently supports either 1 or 2 prediction tasks 
+        :param dropout: [float] value between 0 and 1 for the probability of a reccurent element to be zero  
         :param flow_in_temp: [bool] whether the flow predictions should feed
         into the temp predictions
         :param rand_seed: [int] the random seed for initialization
+        :param return_state: [bool] whether the hidden (h) and cell (c) states of LSTM should be returned 
         """
         super().__init__()
         self.hidden_size = hidden_size
@@ -239,10 +242,12 @@ class RGCNModel(tf.keras.Model):
         """
         :param hidden_size: [int] the number of hidden units
         :param A: [numpy array] adjacency matrix
+        :param tasks: [int] number of prediction tasks to perform - currently supports either 1 or 2 prediction tasks 
+        :param dropout: [float] value between 0 and 1 for the probability of a reccurent element to be zero  
         :param flow_in_temp: [bool] whether the flow predictions should feed
         into the temp predictions
         :param rand_seed: [int] the random seed for initialization
-        :param return_state: [bool] whether the h and c states should be returned (for DA)
+        :param return_state: [bool] whether the hidden (h) and cell (c) states of LSTM should be returned 
         """
         super().__init__()
         self.return_state = return_state

--- a/river_dl/RGCN.py
+++ b/river_dl/RGCN.py
@@ -125,24 +125,14 @@ class RGCN(layers.Layer):
                 shape=[1], initializer="zeros", name="b_out"
             )
         else:
-            if self.tasks == 2: 
-                # was W2
-                self.W_out = self.add_weight(
-                    shape=[hidden_size, 2], initializer=w_initializer, name="W_out"
-                )
-                # was b2
-                self.b_out = self.add_weight(
-                    shape=[2], initializer="zeros", name="b_out"
-                )
-            else: 
-                # was W2
-                self.W_out = self.add_weight(
-                    shape=[hidden_size, 1], initializer=w_initializer, name="W_out"
-                )
-                # was b2
-                self.b_out = self.add_weight(
-                    shape=[1], initializer="zeros", name="b_out"
-                )
+            # was W2
+            self.W_out = self.add_weight(
+                shape=[hidden_size, self.tasks], initializer=w_initializer, name="W_out"
+            )
+            # was b2
+            self.b_out = self.add_weight(
+                shape=[self.tasks], initializer="zeros", name="b_out"
+            )
 
     @tf.function
     def call(self, inputs, **kwargs):
@@ -162,8 +152,6 @@ class RGCN(layers.Layer):
             hidden_state_prev = h_update 
             cell_state_prev = c_update 
         for t in range(n_steps):
-            seq, state = self.lstm(inputs[:, t, :], states=[h_update, c_update])
-            h, c = state # are these used anywhere? 
             h_graph = tf.nn.tanh(
                 tf.matmul(
                     self.A,

--- a/river_dl/RGCN.py
+++ b/river_dl/RGCN.py
@@ -98,15 +98,10 @@ class RGCN(layers.Layer):
     def call(self, inputs, **kwargs):
         h_list = []
         c_list = []
-        graph_size = self.A.shape[0]
         n_steps = inputs.shape[1]
         # set the initial h & c states to the supplied h and c states if using DA, or 0's otherwise
-        if kwargs.get('h_init'):
-            hidden_state_prev = tf.cast(kwargs['h_init'], tf.float32)
-            cell_state_prev = tf.cast(kwargs['c_init'], tf.float32)
-        else:
-            hidden_state_prev = tf.zeros([graph_size, self.hidden_size])
-            cell_state_prev = tf.zeros([graph_size, self.hidden_size])
+        hidden_state_prev = tf.cast(kwargs['h_init'], tf.float32)
+        cell_state_prev = tf.cast(kwargs['c_init'], tf.float32)
         for t in range(n_steps):
             h_graph = tf.nn.tanh(
                 tf.matmul(

--- a/river_dl/loss_functions.py
+++ b/river_dl/loss_functions.py
@@ -108,10 +108,10 @@ def rmse_masked_one_var(data, y_pred, var_idx, tasks):
     return rmse(y_true, y_pred)
 
 
-def weighted_masked_rmse(lamb=0.5, tasks=1):
+def weighted_masked_rmse(lambda_aux=0.5, tasks=1):
     """
     calculate a weighted, masked rmse.
-    :param lamb: [float] (short for lambda). The factor that the auxiliary loss
+    :param lambda_aux: [float] The factor that the auxiliary loss
     will be multiplied by before added to the main loss.
     :param tasks: [int] number of prediction tasks to perform - currently supports either 1 or 2 prediction tasks 
     """
@@ -120,7 +120,7 @@ def weighted_masked_rmse(lamb=0.5, tasks=1):
         rmse_main = rmse_masked_one_var(data, y_pred, 0, tasks)
         if tasks == 2: 
             rmse_aux = rmse_masked_one_var(data, y_pred, 1, tasks)
-            rmse_loss = rmse_main + lamb * rmse_aux
+            rmse_loss = rmse_main + lambda_aux * rmse_aux
             return rmse_loss
         else: 
             return rmse_main 

--- a/river_dl/loss_functions.py
+++ b/river_dl/loss_functions.py
@@ -1,4 +1,3 @@
-import numpy as np
 import tensorflow as tf
 
 
@@ -69,38 +68,20 @@ def samplewise_nnse_loss(y_true, y_pred):
     return 1 - nnse_val
 
 
-def nnse_masked_one_var(data, y_pred, var_idx, tasks):
-    y_true, y_pred, weights = y_data_components(data, y_pred, var_idx, tasks)
-    return nnse_loss(y_true, y_pred)
+def multitask_nse(lambdas):
+    return multitask_loss(lambdas, nnse_loss)
 
 
-def nnse_one_var_samplewise(data, y_pred, var_idx, tasks):
-    y_true, y_pred, weights = y_data_components(data, y_pred, var_idx, tasks)
-    return samplewise_nnse_loss(y_true, y_pred)
+def multitask_samplewise_nse(lambdas):
+    return multitask_loss(lambdas, samplewise_nnse_loss)
 
 
-def y_data_components(data, y_pred, var_idx, tasks):
-    weights = data[:, :, -tasks:]
-    y_true = data[:, :, :-tasks]
-
-    # ensure y_pred, weights, and y_true are all tensors the same data type
-    y_true = tf.convert_to_tensor(y_true)
-    weights = tf.convert_to_tensor(weights)
-    y_true = tf.cast(y_true, y_pred.dtype)
-    weights = tf.cast(weights, y_pred.dtype)
-
-    # make all zero-weighted observations 'nan' so they don't get counted
-    # at all in the loss calculation
-    y_true = tf.where(weights == 0, np.nan, y_true)
-
-    weights = weights[:, :, var_idx]
-    y_true = y_true[:, :, var_idx]
-    y_pred = y_pred[:, :, var_idx]
-    return y_true, y_pred, weights
-
-
-def weighted_masked_rmse(lambdas):
+def multitask_rmse(lambdas):
     return multitask_loss(lambdas, rmse)
+
+
+def multitask_kge(lambdas):
+    return multitask_loss(lambdas, kge_loss)
 
 
 def multitask_loss(lambdas, loss_func):
@@ -183,11 +164,6 @@ def kge_norm_loss(y_true, y_pred):
     making it a loss, so low is good, high is bad
     """
     return 1 - norm_kge(y_true, y_pred)
-
-
-def kge_loss_one_var(data, y_pred, var_idx, tasks):
-    y_true, y_pred, weights = y_data_components(data, y_pred, var_idx, tasks)
-    return kge_loss(y_true, y_pred)
 
 
 def kge_loss(y_true, y_pred):

--- a/river_dl/loss_functions.py
+++ b/river_dl/loss_functions.py
@@ -69,19 +69,23 @@ def samplewise_nnse_loss(y_true, y_pred):
     return 1 - nnse_val
 
 
-def nnse_masked_one_var(data, y_pred, var_idx):
-    y_true, y_pred, weights = y_data_components(data, y_pred, var_idx)
+def nnse_masked_one_var(data, y_pred, var_idx, tasks):
+    y_true, y_pred, weights = y_data_components(data, y_pred, var_idx, tasks)
     return nnse_loss(y_true, y_pred)
 
 
-def nnse_one_var_samplewise(data, y_pred, var_idx):
-    y_true, y_pred, weights = y_data_components(data, y_pred, var_idx)
+def nnse_one_var_samplewise(data, y_pred, var_idx, tasks):
+    y_true, y_pred, weights = y_data_components(data, y_pred, var_idx, tasks)
     return samplewise_nnse_loss(y_true, y_pred)
 
 
-def y_data_components(data, y_pred, var_idx):
-    weights = data[:, :, -2:]
-    y_true = data[:, :, :-2]
+def y_data_components(data, y_pred, var_idx, tasks):
+    if tasks == 2: 
+        weights = data[:, :, -2:]
+        y_true = data[:, :, :-2]
+    else: 
+        weights = data[:, :, -1:]
+        y_true = data[:, :, :-1]
 
     # ensure y_pred, weights, and y_true are all tensors the same data type
     y_true = tf.convert_to_tensor(y_true)
@@ -99,8 +103,8 @@ def y_data_components(data, y_pred, var_idx):
     return y_true, y_pred, weights
 
 
-def rmse_masked_one_var(data, y_pred, var_idx):
-    y_true, y_pred, weights = y_data_components(data, y_pred, var_idx)
+def rmse_masked_one_var(data, y_pred, var_idx, tasks):
+    y_true, y_pred, weights = y_data_components(data, y_pred, var_idx, tasks)
     return rmse(y_true, y_pred)
 
 
@@ -181,8 +185,8 @@ def kge_norm_loss(y_true, y_pred):
     return 1 - norm_kge(y_true, y_pred)
 
 
-def kge_loss_one_var(data, y_pred, var_idx):
-    y_true, y_pred, weights = y_data_components(data, y_pred, var_idx)
+def kge_loss_one_var(data, y_pred, var_idx, tasks):
+    y_true, y_pred, weights = y_data_components(data, y_pred, var_idx, tasks)
     return kge_loss(y_true, y_pred)
 
 

--- a/river_dl/loss_functions.py
+++ b/river_dl/loss_functions.py
@@ -103,6 +103,10 @@ def y_data_components(data, y_pred, var_idx, tasks):
     return y_true, y_pred, weights
 
 
+def weighted_masked_rmse(lambdas):
+    return multitask_loss(lambdas, rmse)
+
+
 def multitask_loss(lambdas, loss_func):
     """
     calculate a weighted multi-task loss for a given number of variables with a

--- a/river_dl/loss_functions.py
+++ b/river_dl/loss_functions.py
@@ -93,6 +93,7 @@ def multitask_loss(lambdas, loss_func):
     :param loss_func: [function] Loss function that will be used to calculate
     the loss of each variable. Must take as input parameters [y_true, y_pred]
     """
+
     def combine_loss(y_true, y_pred):
         losses = []
         n_vars = y_pred.shape[-1]
@@ -102,6 +103,7 @@ def multitask_loss(lambdas, loss_func):
             losses.append(weighted_ind_var_loss)
         total_loss = sum(losses)
         return total_loss
+
     return combine_loss
 
 

--- a/river_dl/loss_functions.py
+++ b/river_dl/loss_functions.py
@@ -108,18 +108,22 @@ def rmse_masked_one_var(data, y_pred, var_idx, tasks):
     return rmse(y_true, y_pred)
 
 
-def weighted_masked_rmse(lamb=0.5):
+def weighted_masked_rmse(lamb=0.5, tasks=1):
     """
     calculate a weighted, masked rmse.
     :param lamb: [float] (short for lambda). The factor that the auxiliary loss
     will be multiplied by before added to the main loss.
+    :param tasks: [int] number of prediction tasks to perform - currently supports either 1 or 2 prediction tasks 
     """
 
     def rmse_masked_combined(data, y_pred):
-        rmse_main = rmse_masked_one_var(data, y_pred, 0)
-        rmse_aux = rmse_masked_one_var(data, y_pred, 1)
-        rmse_loss = rmse_main + lamb * rmse_aux
-        return rmse_loss
+        rmse_main = rmse_masked_one_var(data, y_pred, 0, tasks)
+        if tasks == 2: 
+            rmse_aux = rmse_masked_one_var(data, y_pred, 1, tasks)
+            rmse_loss = rmse_main + lamb * rmse_aux
+            return rmse_loss
+        else: 
+            return rmse_main 
 
     return rmse_masked_combined
 

--- a/river_dl/predict.py
+++ b/river_dl/predict.py
@@ -317,7 +317,7 @@ def predict_from_arbitrary_data(
 
     model = load_model_from_weights(
         model_type, model_weights_dir, hidden_size, dist_matrix,
-        um_tasks=num_tasks
+        num_tasks=num_tasks
     )
 
     ds = xr.open_zarr(raw_data_file)

--- a/river_dl/predict.py
+++ b/river_dl/predict.py
@@ -45,7 +45,7 @@ def load_model_from_weights(
     :param model_weights_dir: [str] directory to saved model weights
     :param hidden_size: [int] the number of hidden units in model
     :param dist_matrix: [np array] the distance matrix if using 'rgcn'
-    :param num_tasks: [int] number of tasks (outputs to be predicted)
+    :param num_tasks: [int] number of tasks (variables to be predicted)
     :return: TF model
     """
     if model_type == "rgcn":
@@ -84,7 +84,7 @@ def predict_from_io_data(
     :param outfile: [str] the file where the output data should be stored
     :param logged_q: [bool] whether the discharge was logged in training. if
     True the exponent of the discharge will be taken in the model unscaling
-    :param num_tasks: [int] number of tasks (outputs to be predicted)
+    :param num_tasks: [int] number of tasks (variables to be predicted)
     :return: [pd dataframe] predictions
     """
     io_data = get_data_if_file(io_data)
@@ -297,7 +297,7 @@ def predict_from_arbitrary_data(
     weights are stored
     :param model_type: [str] model to use either 'rgcn', 'lstm', or 'gru'
     :param hidden_size: [int] the number of hidden units in model
-    :param num_tasks: [int] number of tasks (outputs to be predicted)
+    :param num_tasks: [int] number of tasks (variables to be predicted)
     :param seq_len: [int] length of input sequences given to model
     :param dist_matrix: [np array] the distance matrix if using 'rgcn'. if not
     provided, will look for it in the "train_io_data" file.

--- a/river_dl/rnns.py
+++ b/river_dl/rnns.py
@@ -4,6 +4,39 @@ import tensorflow as tf
 from tensorflow.keras import layers
 from river_dl.loss_functions import nnse_masked_one_var, nnse_one_var_samplewise
 
+
+class SingletaskLSTMModel(tf.keras.Model):
+    def __init__(
+            self,
+            hidden_size,
+            recurrent_dropout=0,
+            dropout=0,
+    ):
+        """
+        :param hidden_size: [int] the number of hidden units
+        :param recurrent_dropout: [float] value between 0 and 1 for the probability of a reccurent element to be zero
+        :param dropout: [float] value between 0 and 1 for the probability of an input element to be zero
+        """
+        super().__init__()
+        self.rnn_layer = layers.LSTM(
+            hidden_size,
+            return_sequences=True,
+            stateful=True,
+            return_state=True,
+            recurrent_dropout=recurrent_dropout,
+            dropout=dropout
+        )
+        self.dense_main = layers.Dense(1, name="dense_main")
+        self.h = None
+        self.c = None
+
+    @tf.function
+    def call(self, inputs, **kwargs):
+        x, self.h, self.c = self.rnn_layer(inputs)
+        main_prediction = self.dense_main(x)
+        return main_prediction
+
+
 class LSTMModel(tf.keras.Model):
     def __init__(
         self,
@@ -71,43 +104,43 @@ class LSTMModel(tf.keras.Model):
             y_pred = self(x, training=True)  # forward pass
 
             loss_main = nnse_one_var_samplewise(y, y_pred, 0, self.tasks)
-            if self.tasks == 2: 
+            if self.tasks == 2:
                 loss_aux = nnse_one_var_samplewise(y, y_pred, 1, self.tasks)
 
         trainable_vars = self.trainable_variables
 
         main_out_vars = get_variables(trainable_vars, "dense_main")
-        if self.tasks == 2: 
+        if self.tasks == 2:
             aux_out_vars = get_variables(trainable_vars, "dense_aux")
             shared_vars = get_variables(trainable_vars, "rnn_shared")
 
         # get gradients
         gradient_main_out = tape.gradient(loss_main, main_out_vars)
-        if self.tasks == 2: 
+        if self.tasks == 2:
             gradient_aux_out = tape.gradient(loss_aux, aux_out_vars)
             gradient_shared_main = tape.gradient(loss_main, shared_vars)
             gradient_shared_aux = tape.gradient(loss_aux, shared_vars)
 
-        if self.tasks == 2: 
+        if self.tasks == 2:
             if self.gradient_correction:
                 # adjust auxiliary gradient
                 gradient_shared_aux = adjust_gradient_list(
                     gradient_shared_main, gradient_shared_aux, self.grad_log_file
                 )
-        if self.tasks == 2: 
+        if self.tasks == 2:
             combined_gradient = combine_gradients_list(
                 gradient_shared_main, gradient_shared_aux, lambda_aux=self.lambda_aux
             )
 
         # apply gradients
         self.optimizer.apply_gradients(zip(gradient_main_out, main_out_vars))
-        if self.tasks == 2: 
+        if self.tasks == 2:
             self.optimizer.apply_gradients(zip(gradient_aux_out, aux_out_vars))
             self.optimizer.apply_gradients(zip(combined_gradient, shared_vars))
             return {"loss_main": loss_main, "loss_aux": loss_aux}
-        else: 
-            return {"loss_main": loss_main} 
-        
+        else:
+            return {"loss_main": loss_main}
+
 
 
 class GRUModel(LSTMModel):

--- a/river_dl/rnns.py
+++ b/river_dl/rnns.py
@@ -37,61 +37,48 @@ class SingletaskLSTMModel(tf.keras.Model):
         return main_prediction
 
 
-class LSTMModel(tf.keras.Model):
+class MultitaskLSTMModel(tf.keras.Model):
     def __init__(
         self,
         hidden_size,
         gradient_correction=False,
-        tasks=1, 
         lambda_aux=1,
         recurrent_dropout=0,
         dropout=0,  
         grad_log_file=None,
-        return_state=False,
     ):
         """
         :param hidden_size: [int] the number of hidden units
         :param gradient_correction: [bool] 
-        :param tasks: [int] number of prediction tasks to perform - currently supports either 1 or 2 prediction tasks 
-        :param lambda_aux: [float] 
+        :param lambda_aux: [float]
         :param recurrent_dropout: [float] value between 0 and 1 for the probability of a reccurent element to be zero  
         :param dropout: [float] value between 0 and 1 for the probability of an input element to be zero  
         :param grad_log_file: [str] location of gradient log file 
-        :param return_state: [bool] return the hidden (h) and cell (c) states of LSTM 
         """
         super().__init__()
         self.gradient_correction = gradient_correction
         self.grad_log_file = grad_log_file
-        self.tasks = tasks 
         self.lambda_aux = lambda_aux
-        self.return_state = return_state 
         self.rnn_layer = layers.LSTM(
             hidden_size,
             return_sequences=True,
-            stateful=return_state,
-            return_state=return_state,
+            stateful=True,
+            return_state=True,
             name="rnn_shared",
             recurrent_dropout=recurrent_dropout,
             dropout=dropout
         )
         self.dense_main = layers.Dense(1, name="dense_main")
-        if self.tasks == 2: 
-            self.dense_aux = layers.Dense(1, name="dense_aux")
+        self.dense_aux = layers.Dense(1, name="dense_aux")
+        self.h = None
+        self.c = None
 
     @tf.function
     def call(self, inputs, **kwargs):
-        if self.return_state: 
-            x, h, c = self.rnn_layer(inputs)
-        else:
-            x = self.rnn_layer(inputs)
-            
-        if self.tasks == 1: 
-            main_prediction = self.dense_main(x) 
-            return main_prediction
-        else: 
-            main_prediction = self.dense_main(x)
-            aux_prediction = self.dense_aux(x)
-            return tf.concat([main_prediction, aux_prediction], axis=2)
+        x, self.h, self.c = self.rnn_layer(inputs)
+        main_prediction = self.dense_main(x)
+        aux_prediction = self.dense_aux(x)
+        return tf.concat([main_prediction, aux_prediction], axis=2)
 
     @tf.function
     def train_step(self, data):
@@ -104,46 +91,51 @@ class LSTMModel(tf.keras.Model):
             y_pred = self(x, training=True)  # forward pass
 
             loss_main = nnse_one_var_samplewise(y, y_pred, 0, self.tasks)
-            if self.tasks == 2:
-                loss_aux = nnse_one_var_samplewise(y, y_pred, 1, self.tasks)
+            loss_aux = nnse_one_var_samplewise(y, y_pred, 1, self.tasks)
 
         trainable_vars = self.trainable_variables
 
         main_out_vars = get_variables(trainable_vars, "dense_main")
-        if self.tasks == 2:
-            aux_out_vars = get_variables(trainable_vars, "dense_aux")
-            shared_vars = get_variables(trainable_vars, "rnn_shared")
+        aux_out_vars = get_variables(trainable_vars, "dense_aux")
+        shared_vars = get_variables(trainable_vars, "rnn_shared")
 
         # get gradients
         gradient_main_out = tape.gradient(loss_main, main_out_vars)
-        if self.tasks == 2:
-            gradient_aux_out = tape.gradient(loss_aux, aux_out_vars)
-            gradient_shared_main = tape.gradient(loss_main, shared_vars)
-            gradient_shared_aux = tape.gradient(loss_aux, shared_vars)
+        gradient_aux_out = tape.gradient(loss_aux, aux_out_vars)
+        gradient_shared_main = tape.gradient(loss_main, shared_vars)
+        gradient_shared_aux = tape.gradient(loss_aux, shared_vars)
 
-        if self.tasks == 2:
-            if self.gradient_correction:
-                # adjust auxiliary gradient
-                gradient_shared_aux = adjust_gradient_list(
-                    gradient_shared_main, gradient_shared_aux, self.grad_log_file
-                )
-        if self.tasks == 2:
-            combined_gradient = combine_gradients_list(
-                gradient_shared_main, gradient_shared_aux, lambda_aux=self.lambda_aux
+        if self.gradient_correction:
+            # adjust auxiliary gradient
+            gradient_shared_aux = adjust_gradient_list(
+                gradient_shared_main, gradient_shared_aux, self.grad_log_file
             )
+        combined_gradient = combine_gradients_list(
+            gradient_shared_main, gradient_shared_aux, lambda_aux=self.lambda_aux
+        )
 
         # apply gradients
         self.optimizer.apply_gradients(zip(gradient_main_out, main_out_vars))
-        if self.tasks == 2:
-            self.optimizer.apply_gradients(zip(gradient_aux_out, aux_out_vars))
-            self.optimizer.apply_gradients(zip(combined_gradient, shared_vars))
-            return {"loss_main": loss_main, "loss_aux": loss_aux}
-        else:
-            return {"loss_main": loss_main}
+        self.optimizer.apply_gradients(zip(gradient_aux_out, aux_out_vars))
+        self.optimizer.apply_gradients(zip(combined_gradient, shared_vars))
+        return {"loss_main": loss_main, "loss_aux": loss_aux}
 
 
+class SingletaskGRUModel(SingletaskLSTMModel):
+    def __init__(
+            self,
+            hidden_size,
+    ):
+        """
+        :param hidden_size: [int] the number of hidden units
+        """
+        super().__init__(hidden_size)
+        self.rnn_layer = layers.GRU(
+            hidden_size, return_sequences=True, name="rnn_shared"
+        )
 
-class GRUModel(LSTMModel):
+
+class MultitaskGRUModel(MultitaskLSTMModel):
     def __init__(
         self,
         hidden_size,

--- a/river_dl/rnns.py
+++ b/river_dl/rnns.py
@@ -11,7 +11,8 @@ class LSTMModel(tf.keras.Model):
         gradient_correction=False,
         tasks=1, 
         lamb=1,
-        dropout=0, # I propose changing this to 'recurrent_dropout' and adding another option for 'dropout' since these will map to the options for the tf LSTM layers https://www.tensorflow.org/api_docs/python/tf/keras/layers/LSTMCell ; and also https://arxiv.org/pdf/1512.05287.pdf 
+        recurrent_dropout=0,
+        dropout=0,  
         grad_log_file=None,
         return_state=False,
     ):
@@ -20,7 +21,8 @@ class LSTMModel(tf.keras.Model):
         :param gradient_correction: [bool] 
         :param tasks: [int] number of prediction tasks to perform - currently supports either 1 or 2 prediction tasks 
         :param lamb: [float] 
-        :param dropout: [float] value between 0 and 1 for the probability of a reccurent element to be zero  
+        :param recurrent_dropout: [float] value between 0 and 1 for the probability of a reccurent element to be zero  
+        :param dropout: [float] value between 0 and 1 for the probability of an input element to be zero  
         :param grad_log_file: [str] location of gradient log file 
         :param return_state: [bool] return the hidden (h) and cell (c) states of LSTM 
         """
@@ -36,7 +38,8 @@ class LSTMModel(tf.keras.Model):
             stateful=True,
             return_state=return_state,
             name="rnn_shared",
-            recurrent_dropout=dropout,
+            recurrent_dropout=recurrent_dropout,
+            dropout=dropout
         )
         if self.tasks == 1: 
             self.dense_main = layers.Dense(1, name="dense_main")

--- a/river_dl/rnns.py
+++ b/river_dl/rnns.py
@@ -20,7 +20,7 @@ class LSTMModel(tf.keras.Model):
         :param gradient_correction: [bool] 
         :param tasks: [int] number of prediction tasks to perform - currently supports either 1 or 2 prediction tasks 
         :param lamb: [float] 
-        :param dropout: [float] value between 0 and 1 for the probability of an element to be zero  
+        :param dropout: [float] value between 0 and 1 for the probability of a reccurent element to be zero  
         :param grad_log_file: [str] location of gradient log file 
         :param return_state: [bool] return the hidden (h) and cell (c) states of LSTM 
         """

--- a/river_dl/rnns.py
+++ b/river_dl/rnns.py
@@ -35,7 +35,7 @@ class LSTMModel(tf.keras.Model):
         self.rnn_layer = layers.LSTM(
             hidden_size,
             return_sequences=True,
-            stateful=True,
+            stateful=return_state,
             return_state=return_state,
             name="rnn_shared",
             recurrent_dropout=recurrent_dropout,

--- a/river_dl/rnns.py
+++ b/river_dl/rnns.py
@@ -2,13 +2,13 @@
 from __future__ import print_function, division
 import tensorflow as tf
 from tensorflow.keras import layers
-from river_dl.loss_functions import nnse_masked_one_var, nnse_one_var_samplewise
 
 
-class SingletaskLSTMModel(tf.keras.Model):
+class LSTMModel(tf.keras.Model):
     def __init__(
             self,
             hidden_size,
+            num_tasks=1,
             recurrent_dropout=0,
             dropout=0,
     ):
@@ -18,6 +18,7 @@ class SingletaskLSTMModel(tf.keras.Model):
         :param dropout: [float] value between 0 and 1 for the probability of an input element to be zero
         """
         super().__init__()
+        self.num_tasks = num_tasks,
         self.rnn_layer = layers.LSTM(
             hidden_size,
             return_sequences=True,
@@ -27,163 +28,39 @@ class SingletaskLSTMModel(tf.keras.Model):
             dropout=dropout
         )
         self.dense_main = layers.Dense(1, name="dense_main")
+        if self.num_tasks == 2:
+            self.dense_aux = layers.Dense(1, name="dense_aux")
         self.h = None
         self.c = None
 
     @tf.function
     def call(self, inputs, **kwargs):
         x, self.h, self.c = self.rnn_layer(inputs)
-        main_prediction = self.dense_main(x)
-        return main_prediction
+        if self.num_tasks == 1:
+            main_prediction = self.dense_main(x)
+            return main_prediction
+        elif self.num_tasks == 2:
+            main_prediction = self.dense_main(x)
+            aux_prediction = self.dense_aux(x)
+            return tf.concat([main_prediction, aux_prediction], axis=2)
+        else:
+            raise ValueError(f'This model only supports 1 or 2 tasks (not {self.num_tasks})')
 
 
-class MultitaskLSTMModel(tf.keras.Model):
-    def __init__(
-        self,
-        hidden_size,
-        gradient_correction=False,
-        lambdas=(1, 1),
-        recurrent_dropout=0,
-        dropout=0,  
-        grad_log_file=None,
-    ):
-        """
-        :param hidden_size: [int] the number of hidden units
-        :param gradient_correction: [bool]
-        :param lambdas: [array-like] weights to multiply the loss from each target
-        variable by
-        :param recurrent_dropout: [float] value between 0 and 1 for the probability of a reccurent element to be zero
-        :param dropout: [float] value between 0 and 1 for the probability of an input element to be zero  
-        :param grad_log_file: [str] location of gradient log file 
-        """
-        super().__init__()
-        self.gradient_correction = gradient_correction
-        self.grad_log_file = grad_log_file
-        self.lambdas = lambdas
-        self.rnn_layer = layers.LSTM(
-            hidden_size,
-            return_sequences=True,
-            stateful=True,
-            return_state=True,
-            name="rnn_shared",
-            recurrent_dropout=recurrent_dropout,
-            dropout=dropout
-        )
-        self.dense_main = layers.Dense(1, name="dense_main")
-        self.dense_aux = layers.Dense(1, name="dense_aux")
-        self.h = None
-        self.c = None
-
-    @tf.function
-    def call(self, inputs, **kwargs):
-        x, self.h, self.c = self.rnn_layer(inputs)
-        main_prediction = self.dense_main(x)
-        aux_prediction = self.dense_aux(x)
-        return tf.concat([main_prediction, aux_prediction], axis=2)
-
-    @tf.function
-    def train_step(self, data):
-        x, y = data
-
-        # If I don't do one forward pass before starting the gradient tape,
-        # the thing hangs
-        _ = self(x)
-        with tf.GradientTape(persistent=True) as tape:
-            y_pred = self(x, training=True)  # forward pass
-
-            loss_main = nnse_one_var_samplewise(y, y_pred, 0, self.tasks)
-            loss_aux = nnse_one_var_samplewise(y, y_pred, 1, self.tasks)
-
-        trainable_vars = self.trainable_variables
-
-        main_out_vars = get_variables(trainable_vars, "dense_main")
-        aux_out_vars = get_variables(trainable_vars, "dense_aux")
-        shared_vars = get_variables(trainable_vars, "rnn_shared")
-
-        # get gradients
-        gradient_main_out = tape.gradient(loss_main, main_out_vars)
-        gradient_aux_out = tape.gradient(loss_aux, aux_out_vars)
-        gradient_shared_main = tape.gradient(loss_main, shared_vars)
-        gradient_shared_aux = tape.gradient(loss_aux, shared_vars)
-
-        if self.gradient_correction:
-            # adjust auxiliary gradient
-            gradient_shared_aux = adjust_gradient_list(
-                gradient_shared_main, gradient_shared_aux, self.grad_log_file
-            )
-        combined_gradient = combine_gradients_list(
-            gradient_shared_main, gradient_shared_aux, lambdas=self.lambdas
-        )
-
-        # apply gradients
-        self.optimizer.apply_gradients(zip(gradient_main_out, main_out_vars))
-        self.optimizer.apply_gradients(zip(gradient_aux_out, aux_out_vars))
-        self.optimizer.apply_gradients(zip(combined_gradient, shared_vars))
-        return {"loss_main": loss_main, "loss_aux": loss_aux}
-
-
-class SingletaskGRUModel(SingletaskLSTMModel):
+class GRUModel(LSTMModel):
     def __init__(
             self,
             hidden_size,
+            num_tasks=1,
+            dropout=0,
+            recurrent_dropout=0,
     ):
         """
         :param hidden_size: [int] the number of hidden units
         """
-        super().__init__(hidden_size)
+        super().__init__(hidden_size, num_tasks=num_tasks)
         self.rnn_layer = layers.GRU(
-            hidden_size, return_sequences=True, name="rnn_shared"
+            hidden_size, recurrent_dropout=recurrent_dropout, dropout=dropout, return_sequences=True, name="rnn_shared"
         )
 
 
-class MultitaskGRUModel(MultitaskLSTMModel):
-    def __init__(
-        self,
-        hidden_size,
-        lambdas=(1, 1)
-    ):
-        """
-        :param hidden_size: [int] the number of hidden units
-        """
-        super().__init__(hidden_size, lambdas=lambdas)
-        self.rnn_layer = layers.GRU(
-            hidden_size, return_sequences=True, name="rnn_shared"
-        )
-
-
-def adjust_gradient(main_grad, aux_grad, logfile=None):
-    # flatten tensors
-    main_grad_flat = tf.reshape(main_grad, [-1])
-    aux_grad_flat = tf.reshape(aux_grad, [-1])
-
-    # project and adjust
-    projection = (
-        tf.minimum(tf.reduce_sum(main_grad_flat * aux_grad_flat), 0)
-        * main_grad_flat
-        / tf.reduce_sum(main_grad_flat * main_grad_flat)
-    )
-    if logfile:
-        logfile = "file://" + logfile
-        tf.print(tf.reduce_sum(projection), output_stream=logfile, sep=",")
-    projection = tf.cond(
-        tf.math.is_nan(tf.reduce_sum(projection)),
-        lambda: tf.zeros(aux_grad_flat.shape),
-        lambda: projection,
-    )
-    adjusted = aux_grad_flat - projection
-    return tf.reshape(adjusted, aux_grad.shape)
-
-
-def get_variables(trainable_variables, name):
-    return [v for v in trainable_variables if name in v.name]
-
-
-def combine_gradients_list(main_grads, aux_grads, lambdas=(1, 1)):
-    return [lambdas[0] * main_grads[i] + lambdas[1] * aux_grads[i] for i in range(len(main_grads))]
-
-
-def adjust_gradient_list(main_grads, aux_grads, logfile=None):
-    return [
-        adjust_gradient(main_grads[i], aux_grads[i], logfile)
-        for i in range(len(main_grads))
-    ]

--- a/river_dl/rnns.py
+++ b/river_dl/rnns.py
@@ -41,10 +41,8 @@ class LSTMModel(tf.keras.Model):
             recurrent_dropout=recurrent_dropout,
             dropout=dropout
         )
-        if self.tasks == 1: 
-            self.dense_main = layers.Dense(1, name="dense_main")
-        else: 
-            self.dense_main = layers.Dense(1, name="dense_main")
+        self.dense_main = layers.Dense(1, name="dense_main")
+        if self.tasks == 2: 
             self.dense_aux = layers.Dense(1, name="dense_aux")
 
     @tf.function
@@ -163,4 +161,3 @@ def adjust_gradient_list(main_grads, aux_grads, logfile=None):
         adjust_gradient(main_grads[i], aux_grads[i], logfile)
         for i in range(len(main_grads))
     ]
-

--- a/river_dl/rnns.py
+++ b/river_dl/rnns.py
@@ -10,7 +10,7 @@ class LSTMModel(tf.keras.Model):
     ):
         """
         :param hidden_size: [int] the number of hidden units
-        :param num_tasks: [int] number of tasks (outputs to be predicted)
+        :param num_tasks: [int] number of tasks (variables to be predicted)
         :param recurrent_dropout: [float] value between 0 and 1 for the
         probability of a recurrent element to be zero
         :param dropout: [float] value between 0 and 1 for the probability of an
@@ -54,7 +54,7 @@ class GRUModel(LSTMModel):
     ):
         """
         :param hidden_size: [int] the number of hidden units
-        :param num_tasks: [int] number of tasks (outputs to be predicted)
+        :param num_tasks: [int] number of tasks (variables to be predicted)
         :param recurrent_dropout: [float] value between 0 and 1 for the
         probability of a recurrent element to be zero
         :param dropout: [float] value between 0 and 1 for the probability of an

--- a/river_dl/rnns.py
+++ b/river_dl/rnns.py
@@ -17,6 +17,7 @@ class LSTMModel(tf.keras.Model):
         input element to be zero
         """
         super().__init__()
+        self.hidden_size = hidden_size
         self.num_tasks = num_tasks
         self.rnn_layer = layers.LSTM(
             hidden_size,
@@ -33,6 +34,10 @@ class LSTMModel(tf.keras.Model):
 
     @tf.function
     def call(self, inputs, **kwargs):
+        batch_size = inputs.shape[0]
+        h_init = kwargs.get("h_init", tf.zeros([batch_size, self.hidden_size]))
+        c_init = kwargs.get("c_init", tf.zeros([batch_size, self.hidden_size]))
+        self.rnn_layer.reset_states(states=[h_init, c_init])
         x, h, c = self.rnn_layer(inputs)
         self.states = h, c
         if self.num_tasks == 1:

--- a/river_dl/rnns.py
+++ b/river_dl/rnns.py
@@ -6,26 +6,25 @@ from tensorflow.keras import layers
 
 class LSTMModel(tf.keras.Model):
     def __init__(
-            self,
-            hidden_size,
-            num_tasks=1,
-            recurrent_dropout=0,
-            dropout=0,
+        self, hidden_size, num_tasks=1, recurrent_dropout=0, dropout=0,
     ):
         """
         :param hidden_size: [int] the number of hidden units
-        :param recurrent_dropout: [float] value between 0 and 1 for the probability of a reccurent element to be zero
-        :param dropout: [float] value between 0 and 1 for the probability of an input element to be zero
+        :param num_tasks: [int] number of tasks (outputs to be predicted)
+        :param recurrent_dropout: [float] value between 0 and 1 for the
+        probability of a recurrent element to be zero
+        :param dropout: [float] value between 0 and 1 for the probability of an
+        input element to be zero
         """
         super().__init__()
-        self.num_tasks = num_tasks,
+        self.num_tasks = num_tasks
         self.rnn_layer = layers.LSTM(
             hidden_size,
             return_sequences=True,
             stateful=True,
             return_state=True,
             recurrent_dropout=recurrent_dropout,
-            dropout=dropout
+            dropout=dropout,
         )
         self.dense_main = layers.Dense(1, name="dense_main")
         if self.num_tasks == 2:
@@ -44,23 +43,27 @@ class LSTMModel(tf.keras.Model):
             aux_prediction = self.dense_aux(x)
             return tf.concat([main_prediction, aux_prediction], axis=2)
         else:
-            raise ValueError(f'This model only supports 1 or 2 tasks (not {self.num_tasks})')
+            raise ValueError(
+                f"This model only supports 1 or 2 tasks (not {self.num_tasks})"
+            )
 
 
 class GRUModel(LSTMModel):
     def __init__(
-            self,
-            hidden_size,
-            num_tasks=1,
-            dropout=0,
-            recurrent_dropout=0,
+        self, hidden_size, num_tasks=1, dropout=0, recurrent_dropout=0,
     ):
         """
         :param hidden_size: [int] the number of hidden units
+        :param num_tasks: [int] number of tasks (outputs to be predicted)
+        :param recurrent_dropout: [float] value between 0 and 1 for the
+        probability of a recurrent element to be zero
+        :param dropout: [float] value between 0 and 1 for the probability of an
         """
         super().__init__(hidden_size, num_tasks=num_tasks)
         self.rnn_layer = layers.GRU(
-            hidden_size, recurrent_dropout=recurrent_dropout, dropout=dropout, return_sequences=True, name="rnn_shared"
+            hidden_size,
+            recurrent_dropout=recurrent_dropout,
+            dropout=dropout,
+            return_sequences=True,
+            name="rnn_shared",
         )
-
-

--- a/river_dl/rnns.py
+++ b/river_dl/rnns.py
@@ -72,7 +72,7 @@ class LSTMModel(tf.keras.Model):
 
             loss_main = nnse_one_var_samplewise(y, y_pred, 0, self.tasks)
             if self.tasks == 2: 
-                loss_aux = nnse_one_var_samplewise(y, y_pred, 1, 2)
+                loss_aux = nnse_one_var_samplewise(y, y_pred, 1, self.tasks)
 
         trainable_vars = self.trainable_variables
 

--- a/river_dl/rnns.py
+++ b/river_dl/rnns.py
@@ -29,12 +29,12 @@ class LSTMModel(tf.keras.Model):
         self.dense_main = layers.Dense(1, name="dense_main")
         if self.num_tasks == 2:
             self.dense_aux = layers.Dense(1, name="dense_aux")
-        self.h = None
-        self.c = None
+        self.states = None
 
     @tf.function
     def call(self, inputs, **kwargs):
-        x, self.h, self.c = self.rnn_layer(inputs)
+        x, h, c = self.rnn_layer(inputs)
+        self.states = h, c
         if self.num_tasks == 1:
             main_prediction = self.dense_main(x)
             return main_prediction

--- a/river_dl/train.py
+++ b/river_dl/train.py
@@ -31,7 +31,7 @@ def train_model(
     model_type="rgcn",
     seed=None,
     dropout=0,
-    lamb=1,
+    lambda_aux=1,
     learning_rate_pre=0.005,
     learning_rate_ft=0.01,
 ):
@@ -47,7 +47,7 @@ def train_model(
     :param model_type: [str] which model to use (either 'lstm', 'rgcn', or
     'lstm_grad_correction')
     :param seed: [int] random seed
-    :param lamb: [float] (short for 'lambda') weight between 0 and 1. How much
+    :param lambda_aux: [float] weight between 0 and 1. How much
     to weight the auxiliary rmse is weighted compared to the main rmse. The
     difference between one and lambda becomes the main rmse weight.
     :param learning_rate_pre: [float] the pretrain learning rate
@@ -71,7 +71,7 @@ def train_model(
         batch_size = num_years
 
     if model_type == "lstm":
-        model = LSTMModel(hidden_units, lamb=lamb)
+        model = LSTMModel(hidden_units, lambda_aux=lambda_aux)
     elif model_type == "rgcn":
         model = RGCNModel(
             hidden_units,
@@ -84,12 +84,12 @@ def train_model(
         model = LSTMModel(
             hidden_units,
             gradient_correction=True,
-            lamb=lamb,
+            lambda_aux=lambda_aux,
             dropout=dropout,
             grad_log_file=grad_log_file,
         )
     elif model_type == "gru":
-        model = GRUModel(hidden_units, lamb=lamb)
+        model = GRUModel(hidden_units, lambda_aux=lambda_aux)
 
     if seed:
         os.environ["PYTHONHASHSEED"] = str(seed)
@@ -110,7 +110,7 @@ def train_model(
         )
 
         if model_type == "rgcn":
-            model.compile(optimizer_pre, loss=weighted_masked_rmse(lamb=lamb))
+            model.compile(optimizer_pre, loss=weighted_masked_rmse(lambda_aux=lambda_aux))
         else:
             model.compile(optimizer_pre)
 
@@ -141,7 +141,7 @@ def train_model(
         optimizer_ft = tf.optimizers.Adam(learning_rate=learning_rate_ft)
 
         if model_type == "rgcn":
-            model.compile(optimizer_ft, loss=weighted_masked_rmse(lamb=lamb))
+            model.compile(optimizer_ft, loss=weighted_masked_rmse(lambda_aux=lambda_aux))
         else:
             model.compile(optimizer_ft)
 

--- a/river_dl/train.py
+++ b/river_dl/train.py
@@ -50,7 +50,7 @@ def train_model(
     of a reccurent element to be zero
     :param dropout: [float] value between 0 and 1 for the probability of an
     input element to be zero
-    :param num_tasks: [int] number of tasks (outputs to be predicted)
+    :param num_tasks: [int] number of tasks (variables to be predicted)
     :param learning_rate_pre: [float] the pretrain learning rate
     :param learning_rate_ft: [float] the finetune learning rate
     :return: [tf model]  finetuned model

--- a/river_dl/train.py
+++ b/river_dl/train.py
@@ -99,9 +99,7 @@ def train_model(
         # use built in 'fit' method unless model is grad correction
         x_trn_pre = io_data["x_trn"]
         # combine with weights to pass to loss function
-        y_trn_pre = np.concatenate(
-            [io_data["y_pre_trn"], io_data["y_pre_wgts"]], axis=2
-        )
+        y_trn_pre = io_data["y_pre_trn"]
 
         model.compile(optimizer_pre, loss=loss_func)
 
@@ -138,9 +136,7 @@ def train_model(
         )
 
         x_trn_obs = io_data["x_trn"]
-        y_trn_obs = np.concatenate(
-            [io_data["y_obs_trn"], io_data["y_obs_wgts"]], axis=2
-        )
+        y_trn_obs = io_data["y_obs_trn"]
 
         model.fit(
             x=x_trn_obs,

--- a/river_dl/train.py
+++ b/river_dl/train.py
@@ -46,8 +46,10 @@ def train_model(
     :param model_type: [str] which model to use (either 'lstm', 'rgcn', or
     'gru')
     :param seed: [int] random seed
-    :param recurrent_dropout: [float] value between 0 and 1 for the probability of a reccurent element to be zero
-    :param dropout: [float] value between 0 and 1 for the probability of an input element to be zero
+    :param recurrent_dropout: [float] value between 0 and 1 for the probability
+    of a reccurent element to be zero
+    :param dropout: [float] value between 0 and 1 for the probability of an
+    input element to be zero
     :param num_tasks: [int] number of tasks (outputs to be predicted)
     :param learning_rate_pre: [float] the pretrain learning rate
     :param learning_rate_ft: [float] the finetune learning rate
@@ -70,7 +72,12 @@ def train_model(
         batch_size = num_years
 
     if model_type == "lstm":
-        model = LSTMModel(hidden_units, num_tasks=num_tasks, recurrent_dropout=recurrent_dropout, dropout=dropout)
+        model = LSTMModel(
+            hidden_units,
+            num_tasks=num_tasks,
+            recurrent_dropout=recurrent_dropout,
+            dropout=dropout,
+        )
     elif model_type == "rgcn":
         model = RGCNModel(
             hidden_units,
@@ -78,12 +85,19 @@ def train_model(
             A=dist_matrix,
             rand_seed=seed,
             dropout=dropout,
-            recurrent_dropout=recurrent_dropout
+            recurrent_dropout=recurrent_dropout,
         )
     elif model_type == "gru":
-        model = GRUModel(hidden_units, num_tasks=num_tasks, recurrent_dropout=recurrent_dropout, dropout=dropout)
+        model = GRUModel(
+            hidden_units,
+            num_tasks=num_tasks,
+            recurrent_dropout=recurrent_dropout,
+            dropout=dropout,
+        )
     else:
-        raise ValueError(f"The 'model_type' provided ({model_type}) is not supported")
+        raise ValueError(
+            f"The 'model_type' provided ({model_type}) is not supported"
+        )
 
     if seed:
         os.environ["PYTHONHASHSEED"] = str(seed)

--- a/river_dl/train_model.py
+++ b/river_dl/train_model.py
@@ -60,7 +60,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--num_tasks",
-    help="number of tasks (outputs to be predicted)",
+    help="number of tasks (variables to be predicted)",
     default=1,
     type=int,
 )

--- a/river_dl/train_model.py
+++ b/river_dl/train_model.py
@@ -1,6 +1,23 @@
-import os
 import argparse
 from river_dl.train import train_model
+import river_dl.loss_functions as lf
+
+
+def get_loss_func_from_str(loss_func_str, lambdas=None):
+    if loss_func_str == 'rmse':
+        return lf.rmse
+    elif loss_func_str == 'nse':
+        return lf.nse
+    elif loss_func_str == 'kge':
+        return lf.kge
+    elif loss_func_str == 'multitask_rmse':
+        return lf.multitask_rmse(lambdas)
+    elif loss_func_str == 'multitask_nse':
+        return lf.multitask_nse(lambdas)
+    elif loss_func_str == 'multitask_kge':
+        return lf.multitask_kge(lambdas)
+    else:
+        raise ValueError(f'loss function {loss_func_str} not supported')
 
 
 parser = argparse.ArgumentParser()
@@ -45,11 +62,23 @@ parser.add_argument(
     "--num_tasks", help="number of tasks (outputs to be predicted)", default=1, type=int
 )
 parser.add_argument(
+    "--loss_func", help="loss function", default='rmse', type=str,
+    choices=["rmse", "nse", "kge", "multitask_rmse", "multitask_kge", "multitask_nse"],
+)
+parser.add_argument(
+    "--dropout", help="dropout rate", default=0, type=float
+)
+parser.add_argument(
+    "--recurrent_dropout", help="recurrent dropout", default=0, type=float
+)
+parser.add_argument(
     "--lambdas", help="lambdas for weighting variable losses", default=[1, 1], type=list
 )
 
-
 args = parser.parse_args()
+
+loss_func = get_loss_func_from_str(args.loss_func)
+
 
 # -------- train ------
 model = train_model(
@@ -59,7 +88,9 @@ model = train_model(
     args.hidden_units,
     out_dir=args.out_dir,
     num_tasks=args.num_tasks,
-    lambdas=args.lambdas,
+    loss_func=loss_func,
+    dropout=args.dropout,
+    recurrent_dropout=args.recurrent_dropout,
     seed=args.random_seed,
     learning_rate_ft=args.ft_learn_rate,
     learning_rate_pre=args.pt_learn_rate,

--- a/river_dl/train_model.py
+++ b/river_dl/train_model.py
@@ -4,20 +4,20 @@ import river_dl.loss_functions as lf
 
 
 def get_loss_func_from_str(loss_func_str, lambdas=None):
-    if loss_func_str == 'rmse':
+    if loss_func_str == "rmse":
         return lf.rmse
-    elif loss_func_str == 'nse':
+    elif loss_func_str == "nse":
         return lf.nse
-    elif loss_func_str == 'kge':
+    elif loss_func_str == "kge":
         return lf.kge
-    elif loss_func_str == 'multitask_rmse':
+    elif loss_func_str == "multitask_rmse":
         return lf.multitask_rmse(lambdas)
-    elif loss_func_str == 'multitask_nse':
+    elif loss_func_str == "multitask_nse":
         return lf.multitask_nse(lambdas)
-    elif loss_func_str == 'multitask_kge':
+    elif loss_func_str == "multitask_kge":
         return lf.multitask_kge(lambdas)
     else:
-        raise ValueError(f'loss function {loss_func_str} not supported')
+        raise ValueError(f"loss function {loss_func_str} not supported")
 
 
 parser = argparse.ArgumentParser()
@@ -59,20 +59,34 @@ parser.add_argument(
     default="rgcn",
 )
 parser.add_argument(
-    "--num_tasks", help="number of tasks (outputs to be predicted)", default=1, type=int
+    "--num_tasks",
+    help="number of tasks (outputs to be predicted)",
+    default=1,
+    type=int,
 )
 parser.add_argument(
-    "--loss_func", help="loss function", default='rmse', type=str,
-    choices=["rmse", "nse", "kge", "multitask_rmse", "multitask_kge", "multitask_nse"],
+    "--loss_func",
+    help="loss function",
+    default="rmse",
+    type=str,
+    choices=[
+        "rmse",
+        "nse",
+        "kge",
+        "multitask_rmse",
+        "multitask_kge",
+        "multitask_nse",
+    ],
 )
-parser.add_argument(
-    "--dropout", help="dropout rate", default=0, type=float
-)
+parser.add_argument("--dropout", help="dropout rate", default=0, type=float)
 parser.add_argument(
     "--recurrent_dropout", help="recurrent dropout", default=0, type=float
 )
 parser.add_argument(
-    "--lambdas", help="lambdas for weighting variable losses", default=[1, 1], type=list
+    "--lambdas",
+    help="lambdas for weighting variable losses",
+    default=[1, 1],
+    type=list,
 )
 
 args = parser.parse_args()

--- a/river_dl/train_model.py
+++ b/river_dl/train_model.py
@@ -49,7 +49,7 @@ parser.add_argument(
     default="rgcn",
 )
 parser.add_argument(
-    "--lamb", help="lambda for weighting aux gradient", default=1.0, type=float
+    "--lambda_aux", help="lambda for weighting aux gradient", default=1.0, type=float
 )
 
 
@@ -69,7 +69,7 @@ model = train_model(
     hidden_units,
     out_dir=out_dir,
     flow_in_temp=flow_in_temp,
-    lamb=args.lamb,
+    lambda_aux=args.lambda_aux,
     seed=args.random_seed,
     learning_rate_ft=args.ft_learn_rate,
     learning_rate_pre=args.pt_learn_rate,

--- a/river_dl/train_model.py
+++ b/river_dl/train_model.py
@@ -24,13 +24,6 @@ parser.add_argument(
     "-f", "--finetune_epochs", help="number of finetune" "epochs", type=int
 )
 parser.add_argument(
-    "-q",
-    "--flow-in-temp",
-    help="whether or not to do flow\
-                    in temp",
-    action="store_true",
-)
-parser.add_argument(
     "--pt_learn_rate",
     help="learning rate for pretraining",
     type=float,
@@ -45,31 +38,28 @@ parser.add_argument(
 parser.add_argument(
     "--model",
     help="type of model to train",
-    choices=["lstm", "rgcn"],
+    choices=["lstm", "rgcn", "gru"],
     default="rgcn",
 )
 parser.add_argument(
-    "--lambda_aux", help="lambda for weighting aux gradient", default=1.0, type=float
+    "--num_tasks", help="number of tasks (outputs to be predicted)", default=1, type=int
+)
+parser.add_argument(
+    "--lambdas", help="lambdas for weighting variable losses", default=[1, 1], type=list
 )
 
 
 args = parser.parse_args()
-flow_in_temp = args.flow_in_temp
-in_data_file = args.in_data
-hidden_units = args.hidden_units
-out_dir = args.outdir
-pt_epochs = args.pretrain_epochs
-ft_epochs = args.finetune_epochs
 
 # -------- train ------
 model = train_model(
-    in_data_file,
-    pt_epochs,
-    ft_epochs,
-    hidden_units,
-    out_dir=out_dir,
-    flow_in_temp=flow_in_temp,
-    lambda_aux=args.lambda_aux,
+    args.in_data_file,
+    args.pretrain_epochs,
+    args.finetune_epochs,
+    args.hidden_units,
+    out_dir=args.out_dir,
+    num_tasks=args.num_tasks,
+    lambdas=args.lambdas,
     seed=args.random_seed,
     learning_rate_ft=args.ft_learn_rate,
     learning_rate_pre=args.pt_learn_rate,


### PR DESCRIPTION
I added some functionality to the LSTM and RGCN models so that they can return the h and c states of the LSTM. The LSTM returns the most recent h and c states (i.e. most recent time step), while the RGCN returns the h and c states for every time step since it is looping through each timestep for the LSTM. 

I also added options for predicting either one or two tasks for the LSTM and RGCN. Previously, the models only predicted two tasks (i.e. you had to supply observations for two target features), but now both models should be able to predict either one or two tasks while defaulting to predicting only one tasks. This will be a big update and I didn't change `train.py` or other relevant functions that will call the LSTM/RGCN models because I think we need to first see if these proposed changes will work for all the projects. I also wasn't sure what to call the number of prediction tasks - I ended up calling them `tasks` since that is what @jsadler2 refers to them in his multi-task modeling paper, but I'm open to other suggestions (e.g. targets, target_features, etc..). I had to update some of the loss functions too since they defaulted to assuming the model was predicting 2 modeling tasks. 

Here's[ an example ](https://code.usgs.gov/wma/wp/run-pgdl-da/-/blob/training_model/test_river_dl_lstm.ipynb)of running these models with the new updates. This example is just predicting a single task and returning the h and c states. I show that both the LSTM and RGCN h and c states can be adjusted, updated, and influence the model predictions when supplied to the LSTM / RGCN as initial h and c states. This workflow also works for 2 tasks but it isn't shown right now. 

closes #98, #106 