### PR TITLE
[#111] train_model.py -> train_model_cli.py

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -59,7 +59,7 @@ rule prep_io_data:
 #    shell:
 #        """
 #        module load analytics cuda10.1/toolkit/10.1.105 
-#        run_training -e /home/jsadler/.conda/envs/rgcn --no-node-list "python {code_dir}/train_model.py -o {params.run_dir} -i {input[0]} -p {params.pt_epochs} -f {params.ft_epochs} --lambdas {params.lamb} --loss_func multitask_rmse --model rgcn -s 135"
+#        run_training -e /home/jsadler/.conda/envs/rgcn --no-node-list "python {code_dir}/train_model_cli.py -o {params.run_dir} -i {input[0]} -p {params.pt_epochs} -f {params.ft_epochs} --lambdas {params.lamb} --loss_func multitask_rmse --model rgcn -s 135"
 #        """
 
 

--- a/river_dl/train_model_cli.py
+++ b/river_dl/train_model_cli.py
@@ -1,3 +1,9 @@
+"""
+This file provides a commandline interface (CLI) for the `train.train_model`
+function. The commandline interface was originally provided to allow a command
+to be sent to a slurm scheduler which was necessary to train the model using
+GPUs. This has been tested on USGS's Tallgrass supercomputer.
+"""
 import argparse
 from river_dl.train import train_model
 import river_dl.loss_functions as lf


### PR DESCRIPTION
renaming `train_model.py` to `train_model_cli.py`

closes #111 