### PR TITLE
move task definition from snakefile to config

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -32,8 +32,8 @@ rule prep_io_data:
                   y_data_file=input[1],
                   distfile=input[2],
                   x_vars=config['x_vars'],
-                  y_vars_pretrain=['seg_tave_water', 'seg_outflow'],
-                  y_vars_finetune=['temp_c', 'discharge_cms'],
+                  y_vars_pretrain=config['y_vars_pretrain'],
+                  y_vars_finetune=config['y_vars_finetune'],
                   catch_prop_file=None,
                   exclude_file=None,
                   train_start_date=config['train_start_date'],
@@ -80,7 +80,7 @@ rule train_model_local_or_cpu:
         run_dir=lambda wildcards, output: os.path.split(output[0][:-1])[0],
     run:
         train_model(input[0], config['pt_epochs'], config['ft_epochs'], config['hidden_size'],
-                    loss_func_ft=loss_function, out_dir=params.run_dir, model_type='rgcn', num_tasks=2)
+                    loss_func_ft=loss_function, out_dir=params.run_dir, model_type='rgcn', num_tasks=len(config['y_vars_finetune']))
 
 rule make_predictions:
     input:
@@ -94,7 +94,7 @@ rule make_predictions:
         predict_from_io_data(model_type='rgcn', model_weights_dir=model_dir,
                              hidden_size=config['hidden_size'], io_data=input[1],
                              partition=wildcards.partition, outfile=output[0],
-                             num_tasks=2)
+                             num_tasks=len(config['y_vars_finetune']))
 
 
 def get_grp_arg(wildcards):

--- a/config.yml
+++ b/config.yml
@@ -9,6 +9,9 @@ code_dir: "river_dl"
 
 x_vars: ["seg_rain", "seg_tave_air", "seginc_swrad", "seg_length", "seginc_potet", "seg_slope", "seg_humid", "seg_elev"]
 
+y_vars_pretrain: ['seg_tave_water', 'seg_outflow']
+y_vars_finetune: ['temp_c', 'discharge_cms']
+
 lambdas: [1,0]
 
 

--- a/config.yml
+++ b/config.yml
@@ -1,15 +1,15 @@
 # Input files
-obs_file: "data_DRB/obs_temp_flow_subset"
-sntemp_file: "data_DRB/uncal_sntemp_input_output_subset"
-dist_matrix: "data_DRB/distance_matrix_subset.npz"
+obs_file: "data_DRB/obs_temp_flow_full"
+sntemp_file: "data_DRB/sntemp_inputs_outputs_drb"
+dist_matrix: "data_DRB/distance_matrix.npz"
 
-out_dir: "output_DRB_test"
+out_dir: "output_DRB_updatedInputs_repeated_base"
 
 code_dir: "river_dl"
 
 x_vars: ["seg_rain", "seg_tave_air", "seginc_swrad", "seg_length", "seginc_potet", "seg_slope", "seg_humid", "seg_elev"]
 
-lambdas: [1,1]
+lambdas: [1,0]
 
 
 train_start_date:
@@ -27,6 +27,6 @@ test_end_date:
   - '1985-09-30'
   - '2021-09-30'
 
-pt_epochs: 2
-ft_epochs: 2
+pt_epochs: 200
+ft_epochs: 100
 hidden_size: 20


### PR DESCRIPTION
This moves the definition of the y variables (for both pretraining and finetuning) into the config file rather than having them hard coded into the Snakefile. Also, the number of tasks for predicting and training is determined from the number of y variable names rather than being specified.