### PR TITLE
No pretraining exp

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -75,19 +75,21 @@ rule train_model_local_or_cpu:
         "{outdir}/prepped.npz"
     output:
         directory("{outdir}/trained_weights/"),
-        directory("{outdir}/pretrained_weights/"),
+        #directory("{outdir}/pretrained_weights/"),
+        "{outdir}/prepped2.npz",
     params:
         # getting the base path to put the training outputs in
         # I omit the last slash (hence '[:-1]' so the split works properly
         run_dir=lambda wildcards, output: os.path.split(output[0][:-1])[0],
     run:
         train_model(input[0], config['pt_epochs'], config['ft_epochs'], config['hidden_size'],
-                    loss_func_ft=loss_function, out_dir=params.run_dir, model_type='rgcn', num_tasks=len(config['y_vars_finetune']))
+                    loss_func_ft=loss_function, out_dir=params.run_dir, model_type='rgcn', num_tasks=len(config['y_vars_finetune']),
+                    updated_io_data=output[1])
 
 rule make_predictions:
     input:
         "{outdir}/trained_weights/",
-        "{outdir}/prepped.npz"
+        "{outdir}/prepped2.npz"
     output:
         "{outdir}/{partition}_preds.feather",
     group: 'train_predict_evaluate'
@@ -132,7 +134,7 @@ rule combine_metrics:
 
 rule plot_prepped_data:
     input:
-        "{outdir}/prepped.npz",
+        "{outdir}/prepped2.npz",
     output:
         "{outdir}/{variable}_{partition}.png",
     run:

--- a/config.yml
+++ b/config.yml
@@ -1,38 +1,109 @@
 # Input files
-obs_file: "data_DRB/Obs_temp_flow_drb_Christiana"
-sntemp_file: "data_DRB/sntemp_inputs_outputs_drb_Christiana"
-dist_matrix: "data_DRB/distance_matrix_drb_Christiana.npz"
+obs_file: "data_DRB/Obs_temp_flow_drb_full_no3558"
+sntemp_file: "data_DRB/sntemp_inputs_outputs_drb_full_no3558"
+dist_matrix: "data_DRB/distance_matrix_drb_full_no3558.npz"
+reach_attr_file: "data_DRB/reach_attributes_drb.csv"
+
+
+#### for flow modeling, seg_width should be removed from x_vars
+#x_vars: ["seg_rain", "seg_tave_air", "seginc_swrad", "seg_length", "seginc_potet", "seg_slope", "seg_humid", "seg_elev"]
+x_vars: ['seg_ccov', 'seg_elev', 'seg_length', 'seg_rain', 'seg_slope', 'seg_tave_air', 'seg_tave_gw', 'seg_tave_ss', 'seg_tave_upstream', 'seg_upstream_inflow', 'seg_width', 'seginc_gwflow', 'seginc_potet', 'seginc_sroff', 'seginc_ssflow', 'seginc_swrad']
 
 out_dir: "output_DRB_offsetTest"
 
 code_dir: "river_dl"
 
-x_vars: ["seg_rain", "seg_tave_air", "seginc_swrad", "seg_length", "seginc_potet", "seg_slope", "seg_humid", "seg_elev"]
+y_vars_pretrain: ['seg_tave_water']
+y_vars_finetune: ['temp_c']
+#y_vars_pretrain: ['seg_tave_water', 'seg_outflow']
+#y_vars_finetune: ['temp_c', 'discharge_cms']
 
-y_vars_pretrain: ['seg_tave_water', 'seg_outflow']
-y_vars_finetune: ['temp_c', 'discharge_cms']
-
-lambdas: [1,0]
+lambdas: [1]
+#lambdas: [1,0]
 
 trn_offset: 1.0
 tst_val_offset: 1.0
 
-
 train_start_date:
-  - '1985-10-01'
-  - '2016-10-01'
+  - '1984-09-23'
+  - '1985-09-23'
+  - '1986-09-23'
+  - '1987-09-23'
+  - '1988-09-23'
+  - '1989-09-23'
+  - '1990-09-23'
+  - '1991-09-23'
+  - '1992-09-23'
+  - '1993-09-23'
+  - '1994-09-23'
+  - '1995-09-23'
+  - '1996-09-23'
+  - '1997-09-23'
+  - '1998-09-23'
+  - '1999-09-23'
+  - '2000-09-23'
+  - '2001-09-23'
+  - '2002-09-23'
+  - '2003-09-23'
+  - '2004-09-23'
+  - '2005-09-23'
+  - '2006-09-23'
+  - '2007-09-23'
+  - '2008-09-23'
+  - '2009-09-23'
+  - '2015-09-23'
+  - '2016-09-23'
+  - '2017-09-23'
+  - '2018-09-23'
+  - '2019-09-23'
 train_end_date:
-  - '2006-09-30'
-  - '2020-09-30'
-val_start_date: '2006-10-01'
-val_end_date: '2016-09-30'
+  - '1985-06-19'
+  - '1986-06-19'
+  - '1987-06-19'
+  - '1988-06-19'
+  - '1989-06-19'
+  - '1990-06-19'
+  - '1991-06-19'
+  - '1992-06-19'
+  - '1993-06-19'
+  - '1994-06-19'
+  - '1995-06-19'
+  - '1996-06-19'
+  - '1997-06-19'
+  - '1998-06-19'
+  - '1999-06-19'
+  - '2000-06-19'
+  - '2001-06-19'
+  - '2002-06-19'
+  - '2003-06-19'
+  - '2004-06-19'
+  - '2005-06-19'
+  - '2006-06-19'
+  - '2007-06-19'
+  - '2008-06-19'
+  - '2009-06-19'
+  - '2010-06-19'
+  - '2016-06-19'
+  - '2017-06-19'
+  - '2018-06-19'
+  - '2019-06-19'
+  - '2020-06-19'
+val_start_date:
+  - '1979-10-01'
+  - '2010-06-20'
+  - '2020-06-20'
+val_end_date:
+  - '1984-09-22'
+  - '2015-09-22'
+  - '2021-09-30'
 test_start_date:
   - '1980-10-01'
-  - '2020-10-01'
+  - '2020-06-20'
 test_end_date:
-  - '1985-09-30'
+  - '1985-09-22'
   - '2021-09-30'
 
-pt_epochs: 200
-ft_epochs: 100
+
+pt_epochs: 0
+ft_epochs: 300
 hidden_size: 20

--- a/river_dl/train.py
+++ b/river_dl/train.py
@@ -36,6 +36,7 @@ def train_model(
     num_tasks=1,
     learning_rate_pre=0.005,
     learning_rate_ft=0.01,
+    updated_io_data=None
 ):
     """
     train the rgcn
@@ -182,6 +183,44 @@ def train_model(
                     callbacks=[csv_log_ft],
                 )
         else:
+            if pretrain_epochs == 0:
+                print('Using PB outputs as inputs')
+                # Import the pretraining data and append it to the x vars
+                y_trn_pre = io_data["y_pre_trn"]
+                y_trn_pre = np.nan_to_num(y_trn_pre, nan = 0) # has some nans - not great solution
+                x_trn_obs = np.concatenate([x_trn_obs, y_trn_pre], 2) 
+                # Do the same for the validation and testing x vars
+                y_val_pre = io_data["y_pre_val"]
+                y_val_pre = np.nan_to_num(y_val_pre, nan = 0)
+                x_val_obs = io_data["x_val"]
+                x_val_obs = np.concatenate([x_val_obs, y_val_pre], 2)
+                y_tst_pre = io_data["y_pre_tst"]
+                y_tst_pre = np.nan_to_num(y_tst_pre, nan = 0)
+                x_tst_obs = io_data["x_tst"]
+                x_tst_obs = np.concatenate([x_tst_obs, y_tst_pre], 2)
+                # Update the saved file (so that PB outputs are there for eval; generate same file for no PB outputs too)
+                print("Saving the x data with associated pretraining output", x_trn_obs.shape, x_val_obs.shape, x_tst_obs.shape)
+                np.savez_compressed(updated_io_data, x_trn = x_trn_obs, x_val = x_val_obs, x_tst = x_tst_obs,
+                                    x_std = io_data['x_std'], x_mean = io_data['x_mean'], x_vars = io_data['x_vars'],
+                                    ids_trn = io_data['ids_trn'], times_trn = io_data['times_trn'],
+                                    ids_val = io_data['ids_val'], times_val = io_data['times_val'],
+                                    ids_tst = io_data['ids_tst'], times_tst = io_data['times_tst'], dist_matrix = io_data['dist_matrix'],
+                                    y_obs_trn = io_data['y_obs_trn'], y_obs_wgts = io_data['y_obs_wgts'],
+                                    y_obs_val = io_data['y_obs_val'], y_obs_tst = io_data['y_obs_tst'],
+                                    y_std = io_data['y_std'], y_mean = io_data['y_mean'], y_obs_vars = io_data['y_obs_vars'],
+                                    y_pre_trn = io_data['y_pre_trn'], y_pre_wgts = io_data['y_pre_wgts'],
+                                    y_pre_val = io_data['y_pre_val'], y_pre_tst = io_data['y_pre_tst'], y_pre_vars = io_data['y_pre_vars'])
+            else:
+                np.savez_compressed(updated_io_data, x_trn = io_data['x_trn'], x_val = io_data['x_val'], x_tst = io_data['x_tst'],
+                                    x_std = io_data['x_std'], x_mean = io_data['x_mean'], x_vars = io_data['x_vars'],
+                                    ids_trn = io_data['ids_trn'], times_trn = io_data['times_trn'],
+                                    ids_val = io_data['ids_val'], times_val = io_data['times_val'],
+                                    ids_tst = io_data['ids_tst'], times_tst = io_data['times_tst'], dist_matrix = io_data['dist_matrix'],
+                                    y_obs_trn = io_data['y_obs_trn'], y_obs_wgts = io_data['y_obs_wgts'],
+                                    y_obs_val = io_data['y_obs_val'], y_obs_tst = io_data['y_obs_tst'],
+                                    y_std = io_data['y_std'], y_mean = io_data['y_mean'], y_obs_vars = io_data['y_obs_vars'],
+                                    y_pre_trn = io_data['y_pre_trn'], y_pre_wgts = io_data['y_pre_wgts'],
+                                    y_pre_val = io_data['y_pre_val'], y_pre_tst = io_data['y_pre_tst'], y_pre_vars = io_data['y_pre_vars'])
             y_trn_obs = io_data["y_obs_trn"]
             model.fit(
                 x=x_trn_obs,


### PR DESCRIPTION
⚠️ Definitely not merge worthy as-is; documenting experiment ⚠️ 

Regarding #38 

What happens here:
* Compare 5 model runs with process-based (PB) pretraining and 5 runs of using PB outputs as inputs
* Training hyperparameters:
  * Training partition is non-summer months between (1984, 2010) and (2015, 2020); this was an artifact of the existing `config.yml`
  * Likewise, validation partition is all months between (1979, 1984), (2010, 2015), and (2020, 2021); the last interval appears to only have 2 days of data.
* 100 fine tuning epochs and either 0 or 200 pretraining epochs (manually changed in `config.yml` between runs if needed)
  * If 0 pretraining epochs, concatenate the PB outputs to the `x` variable arrays prior to training and rewrite that file (`prepped.npz` -> `prepped2.npz`)
  * After all of this, it occurred to me that the PB pretraining runs get 300 total training updates, while the PB inputs get 100, so I also generated one run with 300 fine tuning epochs and 0 pretraining epochs; I would've done more but Tallgrass had long queues.

Once a run is completed, I copy the output directory to a separate location and rerun (possibly after changing the pretraining epochs); e.g., `cp -r output_DRB_offsetTest/ no_pretrain_1_300/`.

After all the runs were done, I made some plots of the learning/training curves, validation set RMSE by month, time series, and I'm starting to look at the outputs vs input plots (will upload soon). I will add the notebooks to generate those plots shortly (need to clean them up).

**Right now this looks very favorable for using PB pretraining (specifically validation set RMSE by month), but maybe too favorable? It would be nice to get some more eyes to spot any mistakes or oversights. One thing that is definitely strange is the all-over-the-place behavior of PB input models during validation set summers (see last two plots)**.

Plots:

![TrainingCurves_PB_inputs_vs_pretraining](https://user-images.githubusercontent.com/18230221/140101582-4e52a3f1-e28d-4496-9b49-2dee42efec23.png)

![RMSE_by_month_PB_inputs_vs_pretraining (1)](https://user-images.githubusercontent.com/18230221/140101794-589824a7-a137-49d8-a28e-c6c1551b7854.png)

![PB_experiment_TimeSeries1566_300IDd](https://user-images.githubusercontent.com/18230221/140102003-f2b93df2-f2d7-4cad-9f52-2878833cb3d0.png)

![PB_experiment_TimeSeries1573_300IDd](https://user-images.githubusercontent.com/18230221/140102019-defdac06-03fa-4bba-b867-4a10e6f3b6aa.png)
