### PR TITLE
linear algebra option for gw loss

### DIFF
--- a/Snakefile_gw
+++ b/Snakefile_gw
@@ -107,7 +107,7 @@ def get_gw_loss(input_data, temp_var="temp_c"):
     temp_sd = io_data['y_std'][temp_index]
     gw_mean = io_data['GW_mean']
     gw_std = io_data['GW_std']
-    return lf.weighted_masked_rmse_gw(loss_function,temp_index,temp_mean, temp_sd,gw_mean=gw_mean, gw_std = gw_std,lambda_Ar=config['lambdas_gw'][0],lambda_delPhi=config['lambdas_gw'][1], num_task=len(io_data['y_obs_vars']))
+    return lf.weighted_masked_rmse_gw(loss_function,temp_index,temp_mean, temp_sd,gw_mean=gw_mean, gw_std = gw_std,lambda_Ar=config['lambdas_gw'][0],lambda_delPhi=config['lambdas_gw'][1], num_task=len(io_data['y_obs_vars']), gw_type=config['gw_loss_type'])
 
  
 # use "train_model" if wanting to use CPU or local GPU

--- a/config_gw.yml
+++ b/config_gw.yml
@@ -1,10 +1,10 @@
 # Input file
 obs_file: "data_DRB/Obs_temp_flow_drb_full_no3558"
 sntemp_file: "data_DRB/sntemp_inputs_outputs_drb_full_no3558"
-dist_matrix: "data_DRB/distance_matrix_drb_full_no3558.npz"
+dist_matrix_file: "data_DRB/distance_matrix_drb_full_no3558.npz"
 reach_attr_file: "data_DRB/reach_attributes_drb.csv"
 
-out_dir: "output_DRB_offset_1.0_gw_0_0_cli"
+out_dir: "output_DRB_gw_type_test_linalg"
 
 code_dir: "river_dl"
 
@@ -22,6 +22,9 @@ lambdas: [1]
 
 #lambdas_gw are hyper params for weighting the rmses of Ar (amplitude ratio) and deltaPhi (phase difference)
 lambdas_gw: [0, 0]
+
+#gw loss calculation method, either 'fft' (fourier fast transform) or 'linalg' (linear algebra)
+gw_loss_type: 'linalg'
 
 trn_offset: 1.0
 tst_val_offset: 1.0
@@ -47,7 +50,7 @@ test_end_date:
   - '1985-09-30'
   - '2021-09-30'
 
-pt_epochs: 200
-ft_epochs: 100
+pt_epochs: 5
+ft_epochs: 5
 
 hidden_size: 20

--- a/config_gw.yml
+++ b/config_gw.yml
@@ -50,7 +50,7 @@ test_end_date:
   - '1985-09-30'
   - '2021-09-30'
 
-pt_epochs: 5
-ft_epochs: 5
+pt_epochs: 200 
+ft_epochs: 100
 
 hidden_size: 20

--- a/river_dl/gw_utils.py
+++ b/river_dl/gw_utils.py
@@ -336,6 +336,7 @@ def prep_annual_signal_data(
     data['GW_tst']=GW_tst
     data['GW_trn']=GW_trn
     data['GW_val']=GW_val
+    data['GW_vars']=gwVarList
     data['GW_cols']=GW_trn.columns.values.astype('str')
     data['GW_mean']=np.nanmean(GW_trn[['Ar_obs','delPhi_obs']],axis=0)
     data['GW_std']=np.nanstd(GW_trn[['Ar_obs','delPhi_obs']],axis=0)

--- a/river_dl/loss_functions.py
+++ b/river_dl/loss_functions.py
@@ -175,7 +175,7 @@ def kge_norm_loss(y_true, y_pred):
 def kge_loss(y_true, y_pred):
     return -1 * kge(y_true, y_pred)
 
-def weighted_masked_rmse_gw(loss_function_main, temp_index,temp_mean, temp_sd,gw_mean, gw_std, lambda_Ar=0, lambda_delPhi=0, num_task=2):
+def weighted_masked_rmse_gw(loss_function_main, temp_index,temp_mean, temp_sd,gw_mean, gw_std, lambda_Ar=0, lambda_delPhi=0, num_task=2, gw_type='fft'):
     """
     calculate a weighted, masked rmse that includes the groundwater terms
     :param lamb, lamb2, lamb3: [float] (short for lambda). The factor that the auxiliary loss, Ar loss, and deltaPhi loss
@@ -183,11 +183,12 @@ def weighted_masked_rmse_gw(loss_function_main, temp_index,temp_mean, temp_sd,gw
     :param temp_index: [int]. Index of temperature column (0 if temp is the primary prediction, 1 if it is the auxiliary).
     :param temp_mean: [float]. Mean temperature for unscaling the predicted temperatures.
     :param temp_sd: [float]. Standard deviation of temperature for unscalind the predicted temperatures.
+    :param gw_type: [str]. Type of gw loss, either 'fft' (fourier fast transform) or 'linalg' (linear algebra)
     """
 
     def rmse_masked_combined_gw(data, y_pred):
      
-        Ar_obs, Ar_pred, delPhi_obs, delPhi_pred = GW_loss_prep(temp_index,data, y_pred, temp_mean, temp_sd,gw_mean, gw_std, num_task)
+        Ar_obs, Ar_pred, delPhi_obs, delPhi_pred = GW_loss_prep(temp_index,data, y_pred, temp_mean, temp_sd,gw_mean, gw_std, num_task, type=gw_type)
         rmse_Ar = rmse(Ar_obs,Ar_pred)
         rmse_delPhi = rmse(delPhi_obs,delPhi_pred)
 
@@ -201,7 +202,7 @@ def weighted_masked_rmse_gw(loss_function_main, temp_index,temp_mean, temp_sd,gw
     return rmse_masked_combined_gw
 
 
-def GW_loss_prep(temp_index, data, y_pred, temp_mean, temp_sd, gw_mean, gw_std, num_task):
+def GW_loss_prep(temp_index, data, y_pred, temp_mean, temp_sd, gw_mean, gw_std, num_task, type='fft'):
     # assumes that axis 0 of data and y_pred are the reaches and axis 1 are daily values
     # assumes the first two columns of data are the observed flow and temperature, and the remaining
     # ones (extracted here) are the data for gw analysis
@@ -210,41 +211,73 @@ def GW_loss_prep(temp_index, data, y_pred, temp_mean, temp_sd, gw_mean, gw_std, 
     y_pred_temp = y_pred[:, :, int(temp_index):(int(temp_index) + 1)]  # extract just the predicted temperature
     # unscale the predicted temps prior to calculating the amplitude and phase
     y_pred_temp = y_pred_temp * temp_sd + temp_mean
-    y_pred_temp = tf.squeeze(y_pred_temp)
-    y_pred_mean = tf.reduce_mean(y_pred_temp, 1, keepdims=True)
-    temp_demean = y_pred_temp - y_pred_mean
-    fft_tf = tf.signal.rfft(temp_demean)
-    Phiw = tf.math.angle(fft_tf)
-    phiIndex = tf.argmax(tf.abs(fft_tf), 1)
-    idx = tf.stack(
-        [tf.reshape(tf.range(tf.shape(Phiw)[0]), (-1, 1)),
-         tf.reshape(tf.cast(phiIndex, tf.int32), (tf.shape(phiIndex)[0], 1))],
-        axis=-1)
-    Phiw_out = tf.squeeze(tf.gather_nd(Phiw, idx))
+    
+    if type=='fft':
+        y_pred_temp = tf.squeeze(y_pred_temp)
+        y_pred_mean = tf.reduce_mean(y_pred_temp, 1, keepdims=True)
+        temp_demean = y_pred_temp - y_pred_mean
+        fft_tf = tf.signal.rfft(temp_demean)
+        Phiw = tf.math.angle(fft_tf)
+        phiIndex = tf.argmax(tf.abs(fft_tf), 1)
+        idx = tf.stack(
+            [tf.reshape(tf.range(tf.shape(Phiw)[0]), (-1, 1)),
+             tf.reshape(tf.cast(phiIndex, tf.int32), (tf.shape(phiIndex)[0], 1))],
+            axis=-1)
+        Phiw_out = tf.squeeze(tf.gather_nd(Phiw, idx))
 
-    Aw = tf.reduce_max(tf.abs(fft_tf), 1) / fft_tf.shape[1]  # tf.shape(fft_tf, out_type=tf.dtypes.float32)[1]
+        Aw = tf.reduce_max(tf.abs(fft_tf), 1) / fft_tf.shape[1]  # tf.shape(fft_tf, out_type=tf.dtypes.float32)[1]
 
-    y_true_air = y_true[:, :, -1]
-    y_true_air_mean = tf.reduce_mean(y_true_air, 1, keepdims=True)
-    air_demean = y_true_air - y_true_air_mean
-    fft_tf_air = tf.signal.rfft(air_demean)
-    Phia = tf.math.angle(fft_tf_air)
+        y_true_air = y_true[:, :, -1]
+        y_true_air_mean = tf.reduce_mean(y_true_air, 1, keepdims=True)
+        air_demean = y_true_air - y_true_air_mean
+        fft_tf_air = tf.signal.rfft(air_demean)
+        Phia = tf.math.angle(fft_tf_air)
 
-    phiIndex_air = tf.argmax(tf.abs(fft_tf_air), 1)
-    ida = tf.stack(
-        [tf.reshape(tf.range(tf.shape(Phia)[0]), (-1, 1)),
-         tf.reshape(tf.cast(phiIndex_air, tf.int32), (tf.shape(phiIndex_air)[0], 1))],
-        axis=-1)
-    Phia_out = tf.squeeze(tf.gather_nd(Phia, ida))
+        phiIndex_air = tf.argmax(tf.abs(fft_tf_air), 1)
+        ida = tf.stack(
+            [tf.reshape(tf.range(tf.shape(Phia)[0]), (-1, 1)),
+             tf.reshape(tf.cast(phiIndex_air, tf.int32), (tf.shape(phiIndex_air)[0], 1))],
+            axis=-1)
+        Phia_out = tf.squeeze(tf.gather_nd(Phia, ida))
 
-    Aa = tf.reduce_max(tf.abs(fft_tf_air), 1) / fft_tf.shape[1]  # tf.shape(fft_tf_air, out_type=tf.dtypes.float32)[1]
+        Aa = tf.reduce_max(tf.abs(fft_tf_air), 1) / fft_tf.shape[1]  # tf.shape(fft_tf_air, out_type=tf.dtypes.float32)[1]
 
-    # calculate and scale predicted values
-    # delPhi_pred = the difference in phase between the water temp and air temp sinusoids, in days
-    delPhi_pred = ((Phiw_out - Phia_out) * 365 / (2 * m.pi) - gw_mean[1]) / gw_std[1]
-    # Ar_pred = the ratio of the water temp and air temp amplitudes
-    Ar_pred = (Aw / Aa - gw_mean[0]) / gw_std[0]
+        # calculate and scale predicted values
+        # delPhi_pred = the difference in phase between the water temp and air temp sinusoids, in days
+        delPhi_pred = ((Phiw_out - Phia_out) * 365 / (2 * m.pi) - gw_mean[1]) / gw_std[1]
+        # Ar_pred = the ratio of the water temp and air temp amplitudes
+        Ar_pred = (Aw / Aa - gw_mean[0]) / gw_std[0]
+    elif type=="linalg":
+        x_lm = y_true[:,:,-3:-1] #extract the sin(wt) and cos(wt)
 
+        #a tensor of the sin(wt) and cos(wt) for each reach x day, the 1's are for the intercept of the linear regression
+        # T(t) = T_mean + a*sin(wt) + b*cos(wt)
+        # Johnson, Z.C., Johnson, B.G., Briggs, M.A., Snyder, C.D., Hitt, N.P., and Devine, W.D., 2021, Heed the data gap: Guidelines for 
+        #using incomplete datasets in annual stream temperature analyses: Ecological Indicators, v. 122, p. 107229, 
+        #http://www.sciencedirect.com/science/article/pii/S1470160X20311687.
+
+        X_mat=tf.stack((tf.constant(1., shape=y_pred_temp.shape[0:2]), x_lm[:,:,0],x_lm[:,:,1]),axis=1)
+        #getting the coefficients using a 3-d version of the normal equation:
+        #https://cmdlinetips.com/2020/03/linear-regression-using-matrix-multiplication-in-python-using-numpy/
+        #http://mlwiki.org/index.php/Normal_Equation
+        X_mat_T = tf.transpose(X_mat,perm=(0,2,1))
+        X_mat_T_dot = tf.einsum('bij,bjk->bik',X_mat_T,X_mat)#eigensums are used instead of dot products because we want the dot products of axis 1 and 2, not 0
+        X_mat_inv = tf.linalg.pinv(X_mat_T_dot)
+        X_mat_inv_dot = tf.einsum('bij,bjk->bik',X_mat_inv,X_mat_T)#eigensums are used instead of dot products because we want the dot products of axis 1 and 2, not 0
+        a_b = tf.einsum('bij,bik->bjk',X_mat_inv_dot,y_pred_temp)#eigensums are used instead of dot products because we want the dot products of axis 1 and 2, not 0
+        #the tensor a_b has the coefficients from the regression (reach x [[intercept],[a],[b]])
+        #Aw = amplitude of the water temp sinusoid (deg C)
+        #A = sqrt (a^2 + b^2)
+        Aw = tf.math.sqrt(a_b[:,1,0]**2+a_b[:,2,0]**2)
+        #Phiw = phase of the water temp sinusoid (radians)
+        #Phi = (3/2)* pi - atan (b/a) - in radians
+        Phiw = 3*m.pi/2-tf.math.atan(a_b[:,2,0]/a_b[:,1,0])
+        
+        #calculate and scale predicted values
+        #delPhi_pred = the difference in phase between the water temp and air temp sinusoids, in days
+        delPhi_pred = ((Phiw-y_true[:,0,2])*365/(2*m.pi)-gw_mean[1])/gw_std[1]
+        #Ar_pred = the ratio of the water temp and air temp amplitudes
+        Ar_pred = (Aw/y_true[:,0,3]-gw_mean[0])/gw_std[0]
     return y_true[:, 0, 0], Ar_pred, y_true[:, 0, 1], delPhi_pred
 
 

--- a/river_dl/loss_functions.py
+++ b/river_dl/loss_functions.py
@@ -213,6 +213,7 @@ def GW_loss_prep(temp_index, data, y_pred, temp_mean, temp_sd, gw_mean, gw_std, 
     y_pred_temp = y_pred_temp * temp_sd + temp_mean
     
     if type=='fft':
+        print("FFT LOSS")
         y_pred_temp = tf.squeeze(y_pred_temp)
         y_pred_mean = tf.reduce_mean(y_pred_temp, 1, keepdims=True)
         temp_demean = y_pred_temp - y_pred_mean
@@ -248,6 +249,7 @@ def GW_loss_prep(temp_index, data, y_pred, temp_mean, temp_sd, gw_mean, gw_std, 
         # Ar_pred = the ratio of the water temp and air temp amplitudes
         Ar_pred = (Aw / Aa - gw_mean[0]) / gw_std[0]
     elif type=="linalg":
+        print("LINALG LOSS")
         x_lm = y_true[:,:,-3:-1] #extract the sin(wt) and cos(wt)
 
         #a tensor of the sin(wt) and cos(wt) for each reach x day, the 1's are for the intercept of the linear regression


### PR DESCRIPTION
This reinstates the option to use the linear algebra approach for calculating the gw loss. The calculation method is set in the config file (config_gw.yml) with the gw_loss_type flag ('fft' or 'linalg')