### PR TITLE
alternative way of no-pretrain experiment

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1,11 +1,13 @@
 import os
 
+from river_dl.preproc_utils import asRunConfig
 from river_dl.preproc_utils import prep_all_data
 from river_dl.evaluate import combined_metrics
 from river_dl.postproc_utils import plot_obs
 from river_dl.predict import predict_from_io_data
 from river_dl.train import train_model
 from river_dl import loss_functions as lf
+import numpy as np
 
 out_dir = config['out_dir']
 code_dir = config['code_dir']
@@ -13,18 +15,68 @@ loss_function = lf.multitask_rmse(config['lambdas'])
 
 rule all:
     input:
-        expand("{outdir}/{metric_type}_metrics.csv",
+        expand("{outdir}/exp_{exp}/{metric_type}_metrics.csv",
                 outdir=out_dir,
                 metric_type=['overall', 'month', 'reach', 'month_reach'],
+                exp = ['pretrain', 'PBIn']
         ),
+        expand("{outdir}/asRunConfig.yml", outdir=out_dir)
+        
 
-rule prep_io_data:
+rule as_run_config:
+    output:
+        "{outdir}/asRunConfig.yml"
+    run:
+        asRunConfig(config,output[0])
+
+
+def combine_inputs_and_pretrain_outputs(input_data, outfile):
+    print('Using PB outputs as inputs')
+    # Import the pretraining data and append it to the x vars
+    y_trn_pre = io_data["y_pre_trn"]
+    y_trn_pre = np.nan_to_num(y_trn_pre, nan = 0) # has some nans - not great solution
+    x_trn_obs = np.concatenate([x_trn_obs, y_trn_pre], 2) 
+    # Do the same for the validation and testing x vars
+    y_val_pre = io_data["y_pre_val"]
+    y_val_pre = np.nan_to_num(y_val_pre, nan = 0)
+    x_val_obs = io_data["x_val"]
+    x_val_obs = np.concatenate([x_val_obs, y_val_pre], 2)
+    y_tst_pre = io_data["y_pre_tst"]
+    y_tst_pre = np.nan_to_num(y_tst_pre, nan = 0)
+    x_tst_obs = io_data["x_tst"]
+    x_tst_obs = np.concatenate([x_tst_obs, y_tst_pre], 2)
+    # Update the saved file (so that PB outputs are there for eval; generate same file for no PB outputs too)
+    print("Saving the x data with associated pretraining output", x_trn_obs.shape, x_val_obs.shape, x_tst_obs.shape)
+    np.savez_compressed(updated_io_data, x_trn = x_trn_obs, x_val = x_val_obs, x_tst = x_tst_obs,
+    x_std = io_data['x_std'], x_mean = io_data['x_mean'], x_vars = io_data['x_vars'],
+    ids_trn = io_data['ids_trn'], times_trn = io_data['times_trn'],
+    ids_val = io_data['ids_val'], times_val = io_data['times_val'],
+    ids_tst = io_data['ids_tst'], times_tst = io_data['times_tst'], dist_matrix = io_data['dist_matrix'],
+    y_obs_trn = io_data['y_obs_trn'], y_obs_wgts = io_data['y_obs_wgts'],
+    y_obs_val = io_data['y_obs_val'], y_obs_tst = io_data['y_obs_tst'],
+    y_std = io_data['y_std'], y_mean = io_data['y_mean'], y_obs_vars = io_data['y_obs_vars'],
+    y_pre_trn = io_data['y_pre_trn'], y_pre_wgts = io_data['y_pre_wgts'],
+    y_pre_val = io_data['y_pre_val'], y_pre_tst = io_data['y_pre_tst'], y_pre_vars = io_data['y_pre_vars'])
+
+    np.savez_compressed()
+
+
+rule prep_io_data_pb_in:
+    input:
+        "{outdir}/exp_pretrain/prepped.npz"
+    output:
+        "{outdir}/exp_PBIn/prepped.npz"
+    run:
+        combine_inputs_and_pretrain_outputs(input[0], output[0])
+
+
+rule prep_io_data_pretrain:
     input:
          config['sntemp_file'],
          config['obs_file'],
-         config['dist_matrix'],
+         config['dist_matrix_file'],
     output:
-        "{outdir}/prepped.npz"
+        "{outdir}/exp_pretrain/prepped.npz"
     run:
         prep_all_data(
                   x_data_file=input[0],
@@ -72,11 +124,10 @@ rule prep_io_data:
 # use "train_model" if wanting to use CPU or local GPU
 rule train_model_local_or_cpu:
     input:
-        "{outdir}/prepped.npz"
+        "{outdir}/exp_{exp}/prepped.npz"
     output:
-        directory("{outdir}/trained_weights/"),
+        directory("{outdir}/exp_{exp}/trained_weights/"),
         #directory("{outdir}/pretrained_weights/"),
-        "{outdir}/prepped2.npz",
     params:
         # getting the base path to put the training outputs in
         # I omit the last slash (hence '[:-1]' so the split works properly
@@ -88,10 +139,10 @@ rule train_model_local_or_cpu:
 
 rule make_predictions:
     input:
-        "{outdir}/trained_weights/",
-        "{outdir}/prepped2.npz"
+        "{outdir}/exp_{exp}/trained_weights/",
+        "{outdir}/exp_{exp}/prepped.npz"
     output:
-        "{outdir}/{partition}_preds.feather",
+        "{outdir}/exp_{exp}/{partition}_preds.feather",
     group: 'train_predict_evaluate'
     run:
         model_dir = input[0] + '/'
@@ -117,10 +168,10 @@ def get_grp_arg(wildcards):
 rule combine_metrics:
     input:
          config['obs_file'],
-         "{outdir}/trn_preds.feather",
-         "{outdir}/val_preds.feather"
+         "{outdir}/exp_{exp}/trn_preds.feather",
+         "{outdir}/exp_{exp}/val_preds.feather"
     output:
-         "{outdir}/{metric_type}_metrics.csv"
+         "{outdir}/exp_{exp}/{metric_type}_metrics.csv"
     group: 'train_predict_evaluate'
     params:
         grp_arg = get_grp_arg
@@ -134,9 +185,9 @@ rule combine_metrics:
 
 rule plot_prepped_data:
     input:
-        "{outdir}/prepped2.npz",
+        "{outdir}/exp_{exp}/prepped.npz",
     output:
-        "{outdir}/{variable}_{partition}.png",
+        "{outdir}/exp_{exp}/{variable}_{partition}.png",
     run:
         plot_obs(input[0], wildcards.variable, output[0],
                  partition=wildcards.partition)


### PR DESCRIPTION
@jdiaz4302 this is another way of setting up the experiment which, in my opinion, would be a bit clearer and cleaner. It basically makes two changes 
1. the merging code is in the actual Snakefile. This is good because, if possible, it's nice not to have to touch the .py files in river-dl for a single experiment
2. it introduces two "branches" (PBIn and pretrain) by having another wildcard.

Here's what the `dag` looks like:
![image](https://user-images.githubusercontent.com/6943441/140404613-9300922d-d37a-4eba-9daf-856037a2ece1.png)

Happy to talk through it or answer questions if you have them.