### PR TITLE
determinism adjustments

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -93,7 +93,7 @@ rule pre_train:
     run:
         train_model(input[0], config['pt_epochs'], config['hidden_size'], loss_func=loss_function,
                     out_dir=params.run_dir, model_type='rgcn', num_tasks=len(config['y_vars_pretrain']),
-                    learning_rate=0.005, train_type = 'pre', early_stop_patience=None)
+                    learning_rate=0.005, train_type = 'pre', early_stop_patience=None, seed = config['seed'])
 
 
 # Finetune/train the model on observations
@@ -111,7 +111,7 @@ rule finetune_train:
     run:
         train_model(input[0], config['ft_epochs'], config['hidden_size'], loss_func=loss_function,
                     out_dir=params.run_dir, model_type='rgcn', num_tasks=len(config['y_vars_finetune']),
-                    learning_rate=0.01, train_type = 'finetune', early_stop_patience=config['early_stopping'])
+                    learning_rate=0.01, train_type = 'finetune', early_stop_patience=config['early_stopping'], seed = config['seed'])
 
 rule make_predictions:
     input:

--- a/Snakefile_gw
+++ b/Snakefile_gw
@@ -91,10 +91,11 @@ rule prep_ann_temp:
 #        lamb2=config['lamb2'],
 #        lamb3=config['lamb3'],
 #        loss = config['loss_type'],
+#        seed = config['seed']
 #    shell:
 #        """
 #        module load analytics cuda10.1/toolkit/10.1.105 
-#        run_training -e /home/jbarclay/.conda/envs/rgcn --no-node-list "python {code_dir}/train_model_cli.py -o {params.run_dir} -i {input[0]} -p {params.pt_epochs} -f {params.ft_epochs} --lamb {params.lamb} --lamb2 {params.lamb2} --lamb3 {params.lamb3} --model rgcn --loss {params.loss} -s 135"
+#        run_training -e /home/jbarclay/.conda/envs/rgcn --no-node-list "python {code_dir}/train_model_cli.py -o {params.run_dir} -i {input[0]} -p {params.pt_epochs} -f {params.ft_epochs} --lamb {params.lamb} --lamb2 {params.lamb2} --lamb3 {params.lamb3} --model rgcn --loss {params.loss} -s {[arams.seed}]}"
 #        """
 
 #get the GW loss parameters
@@ -123,7 +124,7 @@ rule finetune_train:
     run:
         train_model(input[0],config['ft_epochs'],config['hidden_size'],loss_func=get_gw_loss(input[0]),
             out_dir=params.run_dir,model_type='rgcn',num_tasks=len(config['y_vars_finetune']),
-            learning_rate=0.01,train_type='finetune',early_stop_patience=config['early_stopping'])
+            learning_rate=0.01,train_type='finetune',early_stop_patience=config['early_stopping'], seed = config['seed'])
 
                  
 rule compile_pred_GW_stats:

--- a/Snakefile_gw
+++ b/Snakefile_gw
@@ -95,7 +95,7 @@ rule prep_ann_temp:
 #    shell:
 #        """
 #        module load analytics cuda10.1/toolkit/10.1.105 
-#        run_training -e /home/jbarclay/.conda/envs/rgcn --no-node-list "python {code_dir}/train_model_cli.py -o {params.run_dir} -i {input[0]} -p {params.pt_epochs} -f {params.ft_epochs} --lamb {params.lamb} --lamb2 {params.lamb2} --lamb3 {params.lamb3} --model rgcn --loss {params.loss} -s {[arams.seed}]}"
+#        run_training -e /home/jbarclay/.conda/envs/rgcn --no-node-list "python {code_dir}/train_model_cli.py -o {params.run_dir} -i {input[0]} -p {params.pt_epochs} -f {params.ft_epochs} --lamb {params.lamb} --lamb2 {params.lamb2} --lamb3 {params.lamb3} --model rgcn --loss {params.loss} -s {params.seed}"
 #        """
 
 #get the GW loss parameters

--- a/config.yml
+++ b/config.yml
@@ -55,6 +55,6 @@ test_end_date:
   - '2021-09-30'
 
 
-pt_epochs: 1
+pt_epochs: 200
 ft_epochs: 100
 hidden_size: 20

--- a/config.yml
+++ b/config.yml
@@ -13,6 +13,8 @@ out_dir: "output_DRB_offsetTest"
 
 code_dir: "river_dl"
 
+seed: None #random seed for training
+
 y_vars_pretrain: ['seg_tave_water']
 y_vars_finetune: ['temp_c']
 #y_vars_pretrain: ['seg_tave_water', 'seg_outflow']

--- a/config.yml
+++ b/config.yml
@@ -13,7 +13,7 @@ out_dir: "output_test"
 
 code_dir: "river_dl"
 
-seed: -9999 #random seed for training -9999==No seed, otherwise specify the seed
+seed: False #random seed for training False==No seed, otherwise specify the seed
 
 y_vars_pretrain: ['seg_tave_water']
 y_vars_finetune: ['temp_c']
@@ -55,6 +55,6 @@ test_end_date:
   - '2021-09-30'
 
 
-pt_epochs: 200
+pt_epochs: 1
 ft_epochs: 100
 hidden_size: 20

--- a/config.yml
+++ b/config.yml
@@ -9,11 +9,11 @@ reach_attr_file: "data_DRB/reach_attributes_drb.csv"
 #x_vars: ["seg_rain", "seg_tave_air", "seginc_swrad", "seg_length", "seginc_potet", "seg_slope", "seg_humid", "seg_elev"]
 x_vars: ['seg_ccov', 'seg_elev', 'seg_length', 'seg_rain', 'seg_slope', 'seg_tave_air', 'seg_tave_gw', 'seg_tave_ss', 'seg_tave_upstream', 'seg_upstream_inflow', 'seg_width', 'seginc_gwflow', 'seginc_potet', 'seginc_sroff', 'seginc_ssflow', 'seginc_swrad']
 
-out_dir: "output_DRB_offsetTest"
+out_dir: "output_test"
 
 code_dir: "river_dl"
 
-seed: None #random seed for training
+seed: -9999 #random seed for training -9999==No seed, otherwise specify the seed
 
 y_vars_pretrain: ['seg_tave_water']
 y_vars_finetune: ['temp_c']

--- a/config_gw.yml
+++ b/config_gw.yml
@@ -16,7 +16,7 @@ y_vars_finetune: ['temp_c']
 #y_vars_pretrain: ['seg_tave_water', 'seg_outflow']^M
 ##y_vars_finetune: ['temp_c', 'discharge_cms']^M
 
-seed: -9999 #random seed for training -9999==No seed, otherwise specify the seed
+seed: False #random seed for training False==No seed, otherwise specify the seed
 
 lambdas: [1]
 #lambdas: [1,0]

--- a/config_gw.yml
+++ b/config_gw.yml
@@ -4,7 +4,7 @@ sntemp_file: "data_DRB/sntemp_inputs_outputs_drb_full_no3558"
 dist_matrix_file: "data_DRB/distance_matrix_drb_full_no3558.npz"
 reach_attr_file: "data_DRB/reach_attributes_drb.csv"
 
-out_dir: "output_DRB_gw_type_test_linalg"
+out_dir: "output_test"
 
 code_dir: "river_dl"
 
@@ -16,6 +16,7 @@ y_vars_finetune: ['temp_c']
 #y_vars_pretrain: ['seg_tave_water', 'seg_outflow']^M
 ##y_vars_finetune: ['temp_c', 'discharge_cms']^M
 
+seed: -9999 #random seed for training -9999==No seed, otherwise specify the seed
 
 lambdas: [1]
 #lambdas: [1,0]

--- a/config_gw.yml
+++ b/config_gw.yml
@@ -23,9 +23,6 @@ lambdas: [1]
 #lambdas_gw are hyper params for weighting the rmses of Ar (amplitude ratio) and deltaPhi (phase difference)
 lambdas_gw: [0, 0]
 
-#gw loss calculation method, either 'fft' (fourier fast transform) or 'linalg' (linear algebra)
-gw_loss_type: 'linalg'
-
 trn_offset: 1.0
 tst_val_offset: 1.0
 

--- a/river_dl/gw_utils.py
+++ b/river_dl/gw_utils.py
@@ -261,7 +261,8 @@ def prep_annual_signal_data(
     water_temp_pbm_col = 'seg_tave_water',
     water_temp_obs_col = 'temp_c',
     segs = None,
-    reach_file = None
+    reach_file = None,
+    gw_loss_type = 'fft'
 ):
     """
     add annual air and water temp signal properties (phase and amplitude to
@@ -277,6 +278,7 @@ def prep_annual_signal_data(
     :param water_temp_obs_col: str with the column name of the observed water temperatures in degrees C
     :param air_temp_col: str with the column name of the air temperatures in degrees C
     :param reach_file: str with the file of reach attributes
+    :param gw_loss_type: str with the gw loss method (fft or linalg)
     :returns: phase and amplitude of air and observed water temp, along with the
     phase shift and amplitude ratio
     """
@@ -337,6 +339,7 @@ def prep_annual_signal_data(
     data['GW_trn']=GW_trn
     data['GW_val']=GW_val
     data['GW_vars']=gwVarList
+    data['gw_loss_type']=gw_loss_type
     data['GW_cols']=GW_trn.columns.values.astype('str')
     data['GW_mean']=np.nanmean(GW_trn[['Ar_obs','delPhi_obs']],axis=0)
     data['GW_std']=np.nanstd(GW_trn[['Ar_obs','delPhi_obs']],axis=0)

--- a/river_dl/loss_functions.py
+++ b/river_dl/loss_functions.py
@@ -224,7 +224,8 @@ def GW_loss_prep(temp_index, data, y_pred, temp_mean, temp_sd, gw_mean, gw_std, 
             [tf.reshape(tf.range(tf.shape(Phiw)[0]), (-1, 1)),
              tf.reshape(tf.cast(phiIndex, tf.int32), (tf.shape(phiIndex)[0], 1))],
             axis=-1)
-        Phiw_out = tf.squeeze(tf.gather_nd(Phiw, idx))
+        #Phiw_out = tf.squeeze(tf.gather_nd(Phiw, idx))
+        Phiw_out=Phiw[:,1]
 
         Aw = tf.reduce_max(tf.abs(fft_tf), 1) / fft_tf.shape[1]  # tf.shape(fft_tf, out_type=tf.dtypes.float32)[1]
 
@@ -239,7 +240,8 @@ def GW_loss_prep(temp_index, data, y_pred, temp_mean, temp_sd, gw_mean, gw_std, 
             [tf.reshape(tf.range(tf.shape(Phia)[0]), (-1, 1)),
              tf.reshape(tf.cast(phiIndex_air, tf.int32), (tf.shape(phiIndex_air)[0], 1))],
             axis=-1)
-        Phia_out = tf.squeeze(tf.gather_nd(Phia, ida))
+        #Phia_out = tf.squeeze(tf.gather_nd(Phia, ida))
+        Phia_out=Phia[:,1]
 
         Aa = tf.reduce_max(tf.abs(fft_tf_air), 1) / fft_tf.shape[1]  # tf.shape(fft_tf_air, out_type=tf.dtypes.float32)[1]
 

--- a/river_dl/train.py
+++ b/river_dl/train.py
@@ -177,8 +177,6 @@ def train_model(
             f"The 'model_type' provided ({model_type}) is not supported"
         )
 
-    print("SEED TEST")
-
     if seed:
         os.environ["PYTHONHASHSEED"] = str(seed)
         os.environ["TF_CUDNN_DETERMINISTIC"] = "1"
@@ -186,8 +184,6 @@ def train_model(
         tf.random.set_seed(seed)
         np.random.seed(seed)
         random.seed(seed)
-        print(seed)
-
 
     optimizer = tf.optimizers.Adam(learning_rate=learning_rate)
 

--- a/river_dl/train.py
+++ b/river_dl/train.py
@@ -177,8 +177,7 @@ def train_model(
             f"The 'model_type' provided ({model_type}) is not supported"
         )
 
-    if seed==-9999:
-        seed = None
+    print("SEED TEST")
 
     if seed:
         os.environ["PYTHONHASHSEED"] = str(seed)
@@ -187,6 +186,7 @@ def train_model(
         tf.random.set_seed(seed)
         np.random.seed(seed)
         random.seed(seed)
+        print(seed)
 
 
     optimizer = tf.optimizers.Adam(learning_rate=learning_rate)

--- a/river_dl/train.py
+++ b/river_dl/train.py
@@ -176,10 +176,12 @@ def train_model(
         raise ValueError(
             f"The 'model_type' provided ({model_type}) is not supported"
         )
-
+    if not seed:
+        seed = None
     if seed:
         os.environ["PYTHONHASHSEED"] = str(seed)
         os.environ["TF_CUDNN_DETERMINISTIC"] = "1"
+        os.environ["TF_DETERMINISTIC_OPS"] = "1"
         tf.random.set_seed(seed)
         np.random.seed(seed)
         random.seed(seed)

--- a/river_dl/train.py
+++ b/river_dl/train.py
@@ -176,8 +176,10 @@ def train_model(
         raise ValueError(
             f"The 'model_type' provided ({model_type}) is not supported"
         )
-    if not seed:
+
+    if seed==-9999:
         seed = None
+
     if seed:
         os.environ["PYTHONHASHSEED"] = str(seed)
         os.environ["TF_CUDNN_DETERMINISTIC"] = "1"
@@ -185,6 +187,7 @@ def train_model(
         tf.random.set_seed(seed)
         np.random.seed(seed)
         random.seed(seed)
+
 
     optimizer = tf.optimizers.Adam(learning_rate=learning_rate)
 


### PR DESCRIPTION
The PR makes a couple tweaks to improve the repeatability of the results. In particular it:

1.  Provides the option to specify a random seed in the config file. I wasn't able to get None to pass into the training function, so I put in -9999 and a line in river-dl/train.py to convert the -9999 to None. If someone else has a suggestion to avoid this, that would be great.
2. Adds an environment variable (https://github.com/janetrbarclay/river-dl/blob/8554393adac7ab3e72edcca4ac4da497731aa9f5/river_dl/train.py#L186) for choosing the deterministic operations in tf >= 2.1
3. Removes a potential source of non-determinism in the gw loss 

With these settings (and a specified seed), I did 25 runs of base river-dl (no gw loss function) and the losses were identical to 16 decimals across all epochs