### PR TITLE
reversing deltaPhi order, scaling GW inputs for val and tst partitions

### DIFF
--- a/Snakefile_gw
+++ b/Snakefile_gw
@@ -72,7 +72,8 @@ rule prep_ann_temp:
                   test_start_date=config['test_start_date'],
                   test_end_date=config['test_end_date'], 
                   out_file=output[0],
-                  reach_file= config['reach_attr_file'])
+                  reach_file= config['reach_attr_file'],
+                  gw_loss_type=config['gw_loss_type'])
 
 # use "train" if wanting to use GPU on HPC
 #rule train:
@@ -106,7 +107,7 @@ def get_gw_loss(input_data, temp_var="temp_c"):
     temp_sd = io_data['y_std'][temp_index]
     gw_mean = io_data['GW_mean']
     gw_std = io_data['GW_std']
-    return lf.weighted_masked_rmse_gw(loss_function,temp_index,temp_mean, temp_sd,gw_mean=gw_mean, gw_std = gw_std,lambda_Ar=config['lambdas_gw'][0],lambda_delPhi=config['lambdas_gw'][1], num_task=len(io_data['y_obs_vars']))
+    return lf.weighted_masked_rmse_gw(loss_function,temp_index,temp_mean, temp_sd,gw_mean=gw_mean, gw_std = gw_std,lambda_Ar=config['lambdas_gw'][0],lambda_delPhi=config['lambdas_gw'][1], num_task=len(io_data['y_obs_vars']), gw_type=config['gw_loss_type'])
 
 
 # Finetune/train the model on observations

--- a/config_gw.yml
+++ b/config_gw.yml
@@ -4,7 +4,7 @@ sntemp_file: "data_DRB/sntemp_inputs_outputs_drb_full_no3558"
 dist_matrix_file: "data_DRB/distance_matrix_drb_full_no3558.npz"
 reach_attr_file: "data_DRB/reach_attributes_drb.csv"
 
-out_dir: "output_test"
+out_dir: "output_test_fft"
 
 code_dir: "river_dl"
 

--- a/config_gw.yml
+++ b/config_gw.yml
@@ -4,7 +4,7 @@ sntemp_file: "data_DRB/sntemp_inputs_outputs_drb_full_no3558"
 dist_matrix_file: "data_DRB/distance_matrix_drb_full_no3558.npz"
 reach_attr_file: "data_DRB/reach_attributes_drb.csv"
 
-out_dir: "output_test_fft"
+out_dir: "output_DRB_fft_master_noCLI_switchDelPhi"
 
 code_dir: "river_dl"
 
@@ -16,7 +16,7 @@ y_vars_finetune: ['temp_c']
 #y_vars_pretrain: ['seg_tave_water', 'seg_outflow']^M
 ##y_vars_finetune: ['temp_c', 'discharge_cms']^M
 
-seed: False #random seed for training False==No seed, otherwise specify the seed
+seed: 1234 #random seed for training False==No seed, otherwise specify the seed
 
 lambdas: [1]
 #lambdas: [1,0]

--- a/config_gw.yml
+++ b/config_gw.yml
@@ -22,9 +22,12 @@ lambdas: [1]
 #lambdas: [1,0]
 
 #lambdas_gw are hyper params for weighting the rmses of Ar (amplitude ratio) and deltaPhi (phase difference)
-lambdas_gw: [0, 0]
+lambdas_gw: [0.5, 0.5]
 
-trn_offset: 1.0
+#gw loss calculation method, either 'fft' (fourier fast transform) or 'linalg' (linear algebra)
+gw_loss_type: 'fft'
+
+trn_offset: 1.0 #values other than 1 have not been implemented / tested for the GW loss
 tst_val_offset: 1.0
 
 #Define early stopping criteria, setting this to False will turn off early stopping rounds

--- a/river_dl/RGCN.py
+++ b/river_dl/RGCN.py
@@ -34,7 +34,12 @@ class RGCN(layers.Layer):
         )
 
         ### set up the weights ###
-        w_initializer = tf.initializers.glorot_normal(seed=rand_seed)
+        #w_initializer = tf.initializers.glorot_normal(seed=rand_seed)
+        #testing using the prior initializer to repeat prior results
+        w_initializer = tf.random_normal_initializer(
+            stddev=0.02, seed=rand_seed
+            )
+
 
         # was Wg1
         self.W_graph_h = self.add_weight(

--- a/river_dl/RGCN.py
+++ b/river_dl/RGCN.py
@@ -34,12 +34,8 @@ class RGCN(layers.Layer):
         )
 
         ### set up the weights ###
-        #w_initializer = tf.initializers.glorot_normal(seed=rand_seed)
-        #testing using the prior initializer to repeat prior results
-        w_initializer = tf.random_normal_initializer(
-            stddev=0.02, seed=rand_seed
-            )
-
+        w_initializer = tf.initializers.glorot_normal(seed=rand_seed)
+        
 
         # was Wg1
         self.W_graph_h = self.add_weight(

--- a/river_dl/RGCN.py
+++ b/river_dl/RGCN.py
@@ -35,7 +35,6 @@ class RGCN(layers.Layer):
 
         ### set up the weights ###
         w_initializer = tf.initializers.glorot_normal(seed=rand_seed)
-        
 
         # was Wg1
         self.W_graph_h = self.add_weight(

--- a/river_dl/gw_utils.py
+++ b/river_dl/gw_utils.py
@@ -327,12 +327,20 @@ def prep_annual_signal_data(
     GW_trn_scale['Ar_obs'] = (GW_trn['Ar_obs']-np.nanmean(GW_trn['Ar_obs']))/np.nanstd(GW_trn['Ar_obs'])
     GW_trn_scale['delPhi_obs'] = (GW_trn['delPhi_obs']-np.nanmean(GW_trn['delPhi_obs']))/np.nanstd(GW_trn['delPhi_obs'])
     
+    GW_val_scale = deepcopy(GW_val)
+    GW_val_scale['Ar_obs'] = (GW_val_scale['Ar_obs']-np.nanmean(GW_val_scale['Ar_obs']))/np.nanstd(GW_val_scale['Ar_obs'])
+    GW_val_scale['delPhi_obs'] = (GW_val_scale['delPhi_obs']-np.nanmean(GW_val_scale['delPhi_obs']))/np.nanstd(GW_val_scale['delPhi_obs'])
+    
+    GW_tst_scale = deepcopy(GW_tst)
+    GW_tst_scale['Ar_obs'] = (GW_tst_scale['Ar_obs']-np.nanmean(GW_tst_scale['Ar_obs']))/np.nanstd(GW_tst_scale['Ar_obs'])
+    GW_tst_scale['delPhi_obs'] = (GW_tst_scale['delPhi_obs']-np.nanmean(GW_tst_scale['delPhi_obs']))/np.nanstd(GW_tst_scale['delPhi_obs'])
+    
     #add the GW data to the y_dataset dataset
     preppedData = np.load(io_data_file)
     data = {k:v for  k, v in preppedData.items() if not k.startswith("GW")}
 
     data['GW_trn_reshape']=make_GW_dataset(GW_trn_scale,obs_trn.sel(date=slice(np.min(np.unique(preppedData['times_trn'])), np.max(np.unique(preppedData['times_trn'])))),gwVarList)
-    data['GW_tst_reshape']=make_GW_dataset(GW_tst,obs_tst.sel(date=slice(np.min(np.unique(preppedData['times_tst'])), np.max(np.unique(preppedData['times_tst'])))),gwVarList)
+    data['GW_tst_reshape']=make_GW_dataset(GW_tst_scale,obs_tst.sel(date=slice(np.min(np.unique(preppedData['times_tst'])), np.max(np.unique(preppedData['times_tst'])))),gwVarList)
     data['GW_val_reshape']=make_GW_dataset(GW_val,obs_val.sel(date=slice(np.min(np.unique(preppedData['times_val'])), np.max(np.unique(preppedData['times_val'])))),gwVarList)
 
     data['GW_tst']=GW_tst

--- a/river_dl/gw_utils.py
+++ b/river_dl/gw_utils.py
@@ -328,12 +328,12 @@ def prep_annual_signal_data(
     GW_trn_scale['delPhi_obs'] = (GW_trn['delPhi_obs']-np.nanmean(GW_trn['delPhi_obs']))/np.nanstd(GW_trn['delPhi_obs'])
     
     GW_val_scale = deepcopy(GW_val)
-    GW_val_scale['Ar_obs'] = (GW_val_scale['Ar_obs']-np.nanmean(GW_val_scale['Ar_obs']))/np.nanstd(GW_val_scale['Ar_obs'])
-    GW_val_scale['delPhi_obs'] = (GW_val_scale['delPhi_obs']-np.nanmean(GW_val_scale['delPhi_obs']))/np.nanstd(GW_val_scale['delPhi_obs'])
+    GW_val_scale['Ar_obs'] = (GW_val_scale['Ar_obs']-np.nanmean(GW_trn['Ar_obs']))/np.nanstd(GW_trn['Ar_obs'])
+    GW_val_scale['delPhi_obs'] = (GW_val_scale['delPhi_obs']-np.nanmean(GW_trn['delPhi_obs']))/np.nanstd(GW_trn['delPhi_obs'])
     
     GW_tst_scale = deepcopy(GW_tst)
-    GW_tst_scale['Ar_obs'] = (GW_tst_scale['Ar_obs']-np.nanmean(GW_tst_scale['Ar_obs']))/np.nanstd(GW_tst_scale['Ar_obs'])
-    GW_tst_scale['delPhi_obs'] = (GW_tst_scale['delPhi_obs']-np.nanmean(GW_tst_scale['delPhi_obs']))/np.nanstd(GW_tst_scale['delPhi_obs'])
+    GW_tst_scale['Ar_obs'] = (GW_tst_scale['Ar_obs']-np.nanmean(GW_trn['Ar_obs']))/np.nanstd(GW_trn['Ar_obs'])
+    GW_tst_scale['delPhi_obs'] = (GW_tst_scale['delPhi_obs']-np.nanmean(GW_trn['delPhi_obs']))/np.nanstd(GW_trn['delPhi_obs'])
     
     #add the GW data to the y_dataset dataset
     preppedData = np.load(io_data_file)

--- a/river_dl/gw_utils.py
+++ b/river_dl/gw_utils.py
@@ -32,7 +32,7 @@ def amp_phi (Date, temp, isWater=False, r_thresh=0.8, tempType="obs"):
     #A = sqrt (a^2 + b^2)
     
     #Phi = phase of the temp sinusoid (radians)
-    #Phi = (3/2)* pi - atan (b/a) - in radians
+    #Phi = atan (b/a) - in radians
     
     #convert the date to decimal years
     date_decimal = make_decimal_date(Date)
@@ -70,8 +70,8 @@ def amp_phi (Date, temp, isWater=False, r_thresh=0.8, tempType="obs"):
             amp_low = math.sqrt(np.min(abs(confInt[1]))**2+np.min(abs(confInt[2]))**2)
             amp_high = math.sqrt(np.max(abs(confInt[1]))**2+np.max(abs(confInt[2]))**2)
 
-            phi = 3*math.pi/2-math.atan(results.params[2]/results.params[1])
-            phiRange = [3*math.pi/2-math.atan(confInt[2][x]/confInt[1][y]) for x in range(2) for y in range(2)]
+            phi =math.atan(results.params[2]/results.params[1])
+            phiRange = [math.atan(confInt[2][x]/confInt[1][y]) for x in range(2) for y in range(2)]
             phi_low = np.min(phiRange)
             phi_high = np.max(phiRange)
 
@@ -207,13 +207,13 @@ def annual_temp_stats(thisData, water_temp_pbm_col = 'seg_tave_water_pbm', water
         water_phi_high_obs.append(phi_high)
 
     Ar_obs = [water_amp_obs[x]/air_amp[x] for x in range(len(water_amp_obs))]
-    delPhi_obs = [(water_phi_obs[x]-air_phi[x])*365/(2*math.pi) for x in range(len(water_amp_obs))]
+    delPhi_obs = [(air_phi[x]-water_phi_obs[x])*365/(2*math.pi) for x in range(len(water_amp_obs))]
     
     Ar_low_obs = [water_amp_low_obs[x]/air_amp_high[x] for x in range(len(water_amp_obs))]
     Ar_high_obs = [water_amp_high_obs[x]/air_amp_low[x] for x in range(len(water_amp_obs))]
     
-    delPhi_low_obs = [(water_phi_low_obs[x]-air_phi_high[x])*365/(2*math.pi) for x in range(len(water_amp_obs))]
-    delPhi_high_obs = [(water_phi_high_obs[x]-air_phi_low[x])*365/(2*math.pi) for x in range(len(water_amp_obs))]
+    delPhi_low_obs = [(air_phi_high[x]-water_phi_low_obs[x])*365/(2*math.pi) for x in range(len(water_amp_obs))]
+    delPhi_high_obs = [(air_phi_low[x]-water_phi_high_obs[x])*365/(2*math.pi) for x in range(len(water_amp_obs))]
     
     ########################################################
     #these thresholds were set based on analysis in Hare, D.K., Helton, A.M., Johnson, Z.C., Lane, J.W., and Briggs, M.A.,
@@ -241,7 +241,7 @@ def annual_temp_stats(thisData, water_temp_pbm_col = 'seg_tave_water_pbm', water
     
     
     Ar_pbm = [water_amp_pbm[x]/air_amp[x] for x in range(len(water_amp_pbm))]
-    delPhi_pbm = [(water_phi_pbm[x]-air_phi[x])*365/(2*math.pi) for x in range(len(water_amp_pbm))]
+    delPhi_pbm = [(air_phi[x]-water_phi_pbm[x])*365/(2*math.pi) for x in range(len(water_amp_pbm))]
     
     tempDF = pd.DataFrame({'seg_id_nat':thisData['seg_id_nat'].values, 'air_amp':air_amp,'air_phi':air_phi,'water_amp_obs':water_amp_obs,'water_phi_obs':water_phi_obs,'Ar_obs':Ar_obs,'delPhi_obs':delPhi_obs,'Ar_low_obs':Ar_low_obs, 'Ar_high_obs':Ar_high_obs,'delPhi_low_obs':delPhi_low_obs,'delPhi_high_obs':delPhi_high_obs,'water_amp_pbm':water_amp_pbm,'water_phi_pbm':water_phi_pbm,'Ar_pbm':Ar_pbm,'delPhi_pbm':delPhi_pbm})
     return tempDF
@@ -407,7 +407,7 @@ def merge_pred_obs(gw_obs,obs_col,pred):
     obsDF = pd.DataFrame(gw_obs[obs_col],columns=gw_obs['GW_cols'])
     obsDF = obsDF.merge(pred)
     obsDF['Ar_pred']=obsDF['water_amp_pred']/obsDF['air_amp']
-    obsDF['delPhi_pred'] = (obsDF['water_phi_pred']-obsDF['air_phi'])*365/(2*math.pi)
+    obsDF['delPhi_pred'] = (obsDF['air_phi']-obsDF['water_phi_pred'])*365/(2*math.pi)
     return obsDF
 
 def make_GW_dataset (GW_data,x_data,varList):

--- a/river_dl/gw_utils.py
+++ b/river_dl/gw_utils.py
@@ -341,7 +341,7 @@ def prep_annual_signal_data(
 
     data['GW_trn_reshape']=make_GW_dataset(GW_trn_scale,obs_trn.sel(date=slice(np.min(np.unique(preppedData['times_trn'])), np.max(np.unique(preppedData['times_trn'])))),gwVarList)
     data['GW_tst_reshape']=make_GW_dataset(GW_tst_scale,obs_tst.sel(date=slice(np.min(np.unique(preppedData['times_tst'])), np.max(np.unique(preppedData['times_tst'])))),gwVarList)
-    data['GW_val_reshape']=make_GW_dataset(GW_val,obs_val.sel(date=slice(np.min(np.unique(preppedData['times_val'])), np.max(np.unique(preppedData['times_val'])))),gwVarList)
+    data['GW_val_reshape']=make_GW_dataset(GW_val_scale,obs_val.sel(date=slice(np.min(np.unique(preppedData['times_val'])), np.max(np.unique(preppedData['times_val'])))),gwVarList)
 
     data['GW_tst']=GW_tst
     data['GW_trn']=GW_trn

--- a/river_dl/loss_functions.py
+++ b/river_dl/loss_functions.py
@@ -99,7 +99,6 @@ def multitask_loss(lambdas, loss_func):
     """
 
     def combine_loss(y_true, y_pred):
-        tf.debugging.assert_none_equal(tf.cast(tf.math.count_nonzero(~tf.math.is_nan(y_pred)), tf.int32),0,message="OH NO!! - Predicted temps are all NAN")
         losses = []
         n_vars = y_pred.shape[-1]
         for var_id in range(n_vars):
@@ -252,38 +251,14 @@ def GW_loss_prep(temp_index, data, y_pred, temp_mean, temp_sd, gw_mean, gw_std, 
 
         Aa = tf.reduce_max(tf.abs(fft_tf_air), 1) / fft_tf.shape[1]  # tf.shape(fft_tf_air, out_type=tf.dtypes.float32)[1]
         
-        #and the observed water temp properties
-        y_true_temp = tf.squeeze(y_true_temp)
-        y_true_temp_mean = tf.reduce_mean(y_true_temp, 1, keepdims=True)
-        true_temp_demean = y_true_temp - y_true_temp_mean
-        fft_tf_true_temp = tf.signal.rfft(true_temp_demean)
-        Phiw_obs1 = tf.math.angle(fft_tf_true_temp)
-
-        phiIndex_true_temp = tf.argmax(tf.abs(fft_tf_true_temp), 1)
-        ida = tf.stack(
-            [tf.reshape(tf.range(tf.shape(Phia)[0]), (-1, 1)),
-             tf.reshape(tf.cast(phiIndex_true_temp, tf.int32), (tf.shape(phiIndex_true_temp)[0], 1))],
-            axis=-1)
-        #Phia_out = tf.squeeze(tf.gather_nd(Phia, ida))
-        Phiw_obs=Phiw_obs1[:,1]
-
-        Aw_obs = tf.reduce_max(tf.abs(fft_tf_true_temp), 1) / fft_tf.shape[1]  # tf.shape(fft_tf_air, out_type=tf.dtypes.float32)[1]
-
         # calculate and scale predicted values
         # delPhi_pred = the difference in phase between the water temp and air temp sinusoids, in days
         delPhi_pred = (Phia_out-Phiw_out)
-        #delPhi_pred = tf.cond(tf.reduce_mean(Phiw_out)>tf.reduce_mean(Phia_out),lambda: tf.subtract(Phiw_out, Phia_out),lambda: tf.subtract(Phia_out, Phiw_out))
-        #delPhi_pred = (Phiw_out - Phia_out) if tf.reduce_mean(Phiw_out)>tf.reduce_mean(Phia_out) else (Phia_out-Phiw_out)
         delPhi_pred = (delPhi_pred * 365 / (2 * m.pi) - gw_mean[1]) / gw_std[1]
-        
-        delPhi_obs_update = Phia_out - Phiw_obs
-        #delPhi_obs_update = tf.cond(tf.reduce_mean(Phiw_obs)>tf.reduce_mean(Phia_out),lambda: tf.subtract(Phiw_obs, Phia_out),lambda: tf.subtract(Phia_out, Phiw_obs))
-        #delPhi_pred = (Phiw_out - Phia_out) if tf.reduce_mean(Phiw_out)>tf.reduce_mean(Phia_out) else (Phia_out-Phiw_out)
-        delPhi_obs_update = (delPhi_obs_update * 365 / (2 * m.pi) - gw_mean[1]) / gw_std[1]
         
         # Ar_pred = the ratio of the water temp and air temp amplitudes
         Ar_pred = (Aw / Aa - gw_mean[0]) / gw_std[0]
-        Ar_obs_update = (Aw_obs/Aa - gw_mean[0]) / gw_std[0]
+        
     elif type=="linalg":
         print("LINALG LOSS")
         x_lm = y_true[:,:,-3:-1] #extract the sin(wt) and cos(wt)
@@ -317,30 +292,14 @@ def GW_loss_prep(temp_index, data, y_pred, temp_mean, temp_sd, gw_mean, gw_std, 
         A_air = tf.math.sqrt(a_b_air[:,1,0]**2+a_b_air[:,2,0]**2)
         Phi_air = tf.math.atan(a_b_air[:,2,0]/a_b_air[:,1,0])
         
-        #calculate the observed temp properties
-        a_b_obs = tf.einsum('bij,bik->bjk',X_mat_inv_dot,y_true_temp)
-        Aw_obs = tf.math.sqrt(a_b_obs[:,1,0]**2+a_b_obs[:,2,0]**2)
-        Phiw_obs = tf.math.atan(a_b_obs[:,2,0]/a_b_obs[:,1,0])
-        
         #calculate and scale predicted values
         #delPhi_pred = the difference in phase between the water temp and air temp sinusoids, in days
         delPhi_pred = Phi_air-Phiw
-        #delPhi_pred = tf.cond(tf.reduce_mean(Phiw)>tf.reduce_mean(Phi_air),lambda: tf.subtract(Phiw, Phi_air),lambda: tf.subtract(Phi_air, Phiw))
-        #delPhi_pred = (Phiw - Phi_air) if tf.reduce_mean(Phiw)>tf.reduce_mean(Phi_air) else (Phi_air-Phiw)
         delPhi_pred = (delPhi_pred * 365 / (2 * m.pi) - gw_mean[1]) / gw_std[1]
-        #delPhi_pred = the difference in phase between the water temp and air temp sinusoids, in days
-        delPhi_obs_update = Phi_air-Phiw_obs
-        #delPhi_obs_update = tf.cond(tf.reduce_mean(Phiw_obs)>tf.reduce_mean(Phi_air),lambda: tf.subtract(Phiw_obs, Phi_air),lambda: tf.subtract(Phi_air, Phiw_obs))
-        #delPhi_pred = (Phiw - Phi_air) if tf.reduce_mean(Phiw)>tf.reduce_mean(Phi_air) else (Phi_air-Phiw)
-        delPhi_obs_update = (delPhi_obs_update * 365 / (2 * m.pi) - gw_mean[1]) / gw_std[1]
-        #delPhi_pred = ((Phiw-Phi_air)*365/(2*m.pi)-gw_mean[1])/gw_std[1]
+        
         #Ar_pred = the ratio of the water temp and air temp amplitudes
         Ar_pred = (Aw/A_air-gw_mean[0])/gw_std[0]
-        Ar_obs_update = (Aw_obs/A_air-gw_mean[0])/gw_std[0]
 
-    delPhi_obs = tf.where(tf.math.is_finite(delPhi_obs_update),delPhi_obs_update,delPhi_obs)
-    Ar_obs = tf.where(tf.math.is_finite(Ar_obs_update),Ar_obs_update,Ar_obs)
-    
     return Ar_obs, Ar_pred, delPhi_obs, delPhi_pred
 
 

--- a/river_dl/loss_functions.py
+++ b/river_dl/loss_functions.py
@@ -271,11 +271,13 @@ def GW_loss_prep(temp_index, data, y_pred, temp_mean, temp_sd, gw_mean, gw_std, 
 
         # calculate and scale predicted values
         # delPhi_pred = the difference in phase between the water temp and air temp sinusoids, in days
-        delPhi_pred = tf.cond(tf.reduce_mean(Phiw_out)>tf.reduce_mean(Phia_out),lambda: tf.subtract(Phiw_out, Phia_out),lambda: tf.subtract(Phia_out, Phiw_out))
+        delPhi_pred = (Phiw_out - Phia_out)
+        #delPhi_pred = tf.cond(tf.reduce_mean(Phiw_out)>tf.reduce_mean(Phia_out),lambda: tf.subtract(Phiw_out, Phia_out),lambda: tf.subtract(Phia_out, Phiw_out))
         #delPhi_pred = (Phiw_out - Phia_out) if tf.reduce_mean(Phiw_out)>tf.reduce_mean(Phia_out) else (Phia_out-Phiw_out)
         delPhi_pred = (delPhi_pred * 365 / (2 * m.pi) - gw_mean[1]) / gw_std[1]
         
-        delPhi_obs_update = tf.cond(tf.reduce_mean(Phiw_obs)>tf.reduce_mean(Phia_out),lambda: tf.subtract(Phiw_obs, Phia_out),lambda: tf.subtract(Phia_out, Phiw_obs))
+        delPhi_obs_update = Phiw_obs - Phia_out
+        #delPhi_obs_update = tf.cond(tf.reduce_mean(Phiw_obs)>tf.reduce_mean(Phia_out),lambda: tf.subtract(Phiw_obs, Phia_out),lambda: tf.subtract(Phia_out, Phiw_obs))
         #delPhi_pred = (Phiw_out - Phia_out) if tf.reduce_mean(Phiw_out)>tf.reduce_mean(Phia_out) else (Phia_out-Phiw_out)
         delPhi_obs_update = (delPhi_obs_update * 365 / (2 * m.pi) - gw_mean[1]) / gw_std[1]
         
@@ -322,11 +324,13 @@ def GW_loss_prep(temp_index, data, y_pred, temp_mean, temp_sd, gw_mean, gw_std, 
         
         #calculate and scale predicted values
         #delPhi_pred = the difference in phase between the water temp and air temp sinusoids, in days
-        delPhi_pred = tf.cond(tf.reduce_mean(Phiw)>tf.reduce_mean(Phi_air),lambda: tf.subtract(Phiw, Phi_air),lambda: tf.subtract(Phi_air, Phiw))
+        delPhi_pred = Phiw - Phi_air
+        #delPhi_pred = tf.cond(tf.reduce_mean(Phiw)>tf.reduce_mean(Phi_air),lambda: tf.subtract(Phiw, Phi_air),lambda: tf.subtract(Phi_air, Phiw))
         #delPhi_pred = (Phiw - Phi_air) if tf.reduce_mean(Phiw)>tf.reduce_mean(Phi_air) else (Phi_air-Phiw)
         delPhi_pred = (delPhi_pred * 365 / (2 * m.pi) - gw_mean[1]) / gw_std[1]
         #delPhi_pred = the difference in phase between the water temp and air temp sinusoids, in days
-        delPhi_obs_update = tf.cond(tf.reduce_mean(Phiw_obs)>tf.reduce_mean(Phi_air),lambda: tf.subtract(Phiw_obs, Phi_air),lambda: tf.subtract(Phi_air, Phiw_obs))
+        delPhi_obs_update = Phiw_obs - Phi_air
+        #delPhi_obs_update = tf.cond(tf.reduce_mean(Phiw_obs)>tf.reduce_mean(Phi_air),lambda: tf.subtract(Phiw_obs, Phi_air),lambda: tf.subtract(Phi_air, Phiw_obs))
         #delPhi_pred = (Phiw - Phi_air) if tf.reduce_mean(Phiw)>tf.reduce_mean(Phi_air) else (Phi_air-Phiw)
         delPhi_obs_update = (delPhi_obs_update * 365 / (2 * m.pi) - gw_mean[1]) / gw_std[1]
         #delPhi_pred = ((Phiw-Phi_air)*365/(2*m.pi)-gw_mean[1])/gw_std[1]

--- a/river_dl/loss_functions.py
+++ b/river_dl/loss_functions.py
@@ -271,12 +271,12 @@ def GW_loss_prep(temp_index, data, y_pred, temp_mean, temp_sd, gw_mean, gw_std, 
 
         # calculate and scale predicted values
         # delPhi_pred = the difference in phase between the water temp and air temp sinusoids, in days
-        delPhi_pred = (Phiw_out - Phia_out)
+        delPhi_pred = (Phia_out-Phiw_out)
         #delPhi_pred = tf.cond(tf.reduce_mean(Phiw_out)>tf.reduce_mean(Phia_out),lambda: tf.subtract(Phiw_out, Phia_out),lambda: tf.subtract(Phia_out, Phiw_out))
         #delPhi_pred = (Phiw_out - Phia_out) if tf.reduce_mean(Phiw_out)>tf.reduce_mean(Phia_out) else (Phia_out-Phiw_out)
         delPhi_pred = (delPhi_pred * 365 / (2 * m.pi) - gw_mean[1]) / gw_std[1]
         
-        delPhi_obs_update = Phiw_obs - Phia_out
+        delPhi_obs_update = Phia_out - Phiw_obs
         #delPhi_obs_update = tf.cond(tf.reduce_mean(Phiw_obs)>tf.reduce_mean(Phia_out),lambda: tf.subtract(Phiw_obs, Phia_out),lambda: tf.subtract(Phia_out, Phiw_obs))
         #delPhi_pred = (Phiw_out - Phia_out) if tf.reduce_mean(Phiw_out)>tf.reduce_mean(Phia_out) else (Phia_out-Phiw_out)
         delPhi_obs_update = (delPhi_obs_update * 365 / (2 * m.pi) - gw_mean[1]) / gw_std[1]
@@ -308,28 +308,28 @@ def GW_loss_prep(temp_index, data, y_pred, temp_mean, temp_sd, gw_mean, gw_std, 
         #A = sqrt (a^2 + b^2)
         Aw = tf.math.sqrt(a_b[:,1,0]**2+a_b[:,2,0]**2)
         #Phiw = phase of the water temp sinusoid (radians)
-        #Phi = (3/2)* pi - atan (b/a) - in radians
-        Phiw = 3*m.pi/2-tf.math.atan(a_b[:,2,0]/a_b[:,1,0])
+        #Phi = atan (b/a) - in radians
+        Phiw = tf.math.atan(a_b[:,2,0]/a_b[:,1,0])
         
         #calculate the air properties
         y_true_air = y_true[:, :, -1:]
         a_b_air = tf.einsum('bij,bik->bjk',X_mat_inv_dot,y_true_air)
         A_air = tf.math.sqrt(a_b_air[:,1,0]**2+a_b_air[:,2,0]**2)
-        Phi_air = 3*m.pi/2-tf.math.atan(a_b_air[:,2,0]/a_b_air[:,1,0])
+        Phi_air = tf.math.atan(a_b_air[:,2,0]/a_b_air[:,1,0])
         
         #calculate the observed temp properties
         a_b_obs = tf.einsum('bij,bik->bjk',X_mat_inv_dot,y_true_temp)
         Aw_obs = tf.math.sqrt(a_b_obs[:,1,0]**2+a_b_obs[:,2,0]**2)
-        Phiw_obs = 3*m.pi/2-tf.math.atan(a_b_obs[:,2,0]/a_b_obs[:,1,0])
+        Phiw_obs = tf.math.atan(a_b_obs[:,2,0]/a_b_obs[:,1,0])
         
         #calculate and scale predicted values
         #delPhi_pred = the difference in phase between the water temp and air temp sinusoids, in days
-        delPhi_pred = Phiw - Phi_air
+        delPhi_pred = Phi_air-Phiw
         #delPhi_pred = tf.cond(tf.reduce_mean(Phiw)>tf.reduce_mean(Phi_air),lambda: tf.subtract(Phiw, Phi_air),lambda: tf.subtract(Phi_air, Phiw))
         #delPhi_pred = (Phiw - Phi_air) if tf.reduce_mean(Phiw)>tf.reduce_mean(Phi_air) else (Phi_air-Phiw)
         delPhi_pred = (delPhi_pred * 365 / (2 * m.pi) - gw_mean[1]) / gw_std[1]
         #delPhi_pred = the difference in phase between the water temp and air temp sinusoids, in days
-        delPhi_obs_update = Phiw_obs - Phi_air
+        delPhi_obs_update = Phi_air-Phiw_obs
         #delPhi_obs_update = tf.cond(tf.reduce_mean(Phiw_obs)>tf.reduce_mean(Phi_air),lambda: tf.subtract(Phiw_obs, Phi_air),lambda: tf.subtract(Phi_air, Phiw_obs))
         #delPhi_pred = (Phiw - Phi_air) if tf.reduce_mean(Phiw)>tf.reduce_mean(Phi_air) else (Phi_air-Phiw)
         delPhi_obs_update = (delPhi_obs_update * 365 / (2 * m.pi) - gw_mean[1]) / gw_std[1]


### PR DESCRIPTION
This PR makes 3 changes:

1. It reverses the order of the deltaPhi calculation so that the phase of the water signal is subtracted from the phase of the air signal and does not convert the phase to the day of the year with the maximum temperature. This yields a positive phase difference when the air signal precedes the water signal.
2. It scales the calculated GW inputs for the validation and testing partitions. Previously scaled values were only calculated for the training partition, but scaled values are needed for the new training function that calculates the validation loss for each epoch (from #141)
3. It adds an option to the config file to specify the calculation method for the GW loss (fft or linalg)
