### PR TITLE
Fixes to offset and dropout

### DIFF
--- a/river_dl/RGCN.py
+++ b/river_dl/RGCN.py
@@ -115,6 +115,10 @@ class RGCN(layers.Layer):
                 )
             )
 
+            ## Update dropout masks
+            self.lstm.reset_dropout_mask()
+            self.lstm.reset_recurrent_dropout_mask()
+
             seq, state = self.lstm(
                 inputs[:, t, :], states=[hidden_state_prev, cell_state_prev]
             )

--- a/river_dl/predict.py
+++ b/river_dl/predict.py
@@ -101,9 +101,9 @@ def predict_from_io_data(
     )
 
     if partition == "trn":
-        keep_frac = trn_offset
+        keep_portion = trn_offset
     else:
-        keep_frac = tst_val_offset
+        keep_portion = tst_val_offset
 
     preds = predict(
         model,
@@ -113,7 +113,7 @@ def predict_from_io_data(
         io_data["y_std"],
         io_data["y_mean"],
         io_data["y_obs_vars"],
-        keep_last_frac=keep_frac,
+        keep_last_portion=keep_portion,
         outfile=outfile,
         log_vars=log_vars,
     )
@@ -128,7 +128,7 @@ def predict(
     y_stds,
     y_means,
     y_vars,
-    keep_last_frac=1.0,
+    keep_last_portion=1.0,
     outfile=None,
     log_vars=False,
 ):
@@ -139,10 +139,10 @@ def predict(
     :param pred_ids: [np array] the ids of the segments (same shape as x_data)
     :param pred_dates: [np array] the dates of the segments (same shape as
     x_data)
-    :param keep_last_frac: [float] fraction of the predictions to keep starting
+    :param keep_last_portion: [float] fraction of the predictions to keep starting
     from the *end* of the predictions (0-1). (1 means you keep all of the
     predictions, .75 means you keep the final three quarters of the predictions). Alternatively, if
-    keep_last_frac is > 1 it's taken as an absolute number of predictions to retain from the end of the
+    keep_last_portion is > 1 it's taken as an absolute number of predictions to retain from the end of the
     prediction sequence.
     :param y_stds:[np array] the standard deviation of the y_dataset data
     :param y_means:[np array] the means of the y_dataset data
@@ -156,10 +156,10 @@ def predict(
     y_pred = model.predict(x_data, batch_size=num_segs)
 
     # keep only specified part of predictions
-    if keep_last_frac>1:
-        frac_seq_len = int(y_pred.shape[1]-keep_last_frac)
+    if keep_last_portion>1:
+        frac_seq_len = int(y_pred.shape[1] - keep_last_portion)
     else:
-        frac_seq_len = round(y_pred.shape[1] * (1 - keep_last_frac))
+        frac_seq_len = round(y_pred.shape[1] * (1 - keep_last_portion))
     y_pred = y_pred[:, frac_seq_len:, :]
     pred_ids = pred_ids[:, frac_seq_len:, :]
     pred_dates = pred_dates[:, frac_seq_len:, :]
@@ -253,7 +253,7 @@ def predict_one_date_range(
     *additional* sequence from the first sequence. The additional sequence will
     be the first sequence with the first and last halves swapped. The last half
     of the the first sequence serves as a stand-in spin-up period for ths first
-    half predictions. This option makes most sense only when keep_last_frac=0.5.
+    half predictions. This option makes most sense only when keep_last_portion=0.5.
     :return: [pd dataframe] the predictions
     """
     ds_x_scaled = ds_x_scaled[train_io_data["x_cols"]]
@@ -296,7 +296,7 @@ def predict_one_date_range(
         train_io_data["y_std"],
         train_io_data["y_mean"],
         train_io_data["y_obs_vars"],
-        keep_last_frac=keep_last_frac,
+        keep_last_portion=keep_last_frac,
         log_vars=log_vars,
     )
     return predictions

--- a/river_dl/preproc_utils.py
+++ b/river_dl/preproc_utils.py
@@ -87,8 +87,9 @@ def separate_trn_tst(
 ):
     """
     separate the train data from the test data according to the start and end
-    dates. This assumes your training data is in one continuous block and all
-    the dates that are not in the training are in the testing.
+    dates. This assumes your training data is in one continuous block. Be aware, if your train/test/val partitions are
+    discontinuous (composed of multiple periods), you'll end up with sequences starting in one period and ending in
+    another.
     :param dataset: [xr dataset] input or output data with dims
     :param time_idx_name: [str] name of column that is used for temporal index
         (usually 'time')
@@ -133,11 +134,11 @@ def split_into_batches(data_array, seq_len=365, offset=1.0):
         period = offset
     else:
         period = int(offset*seq_len)
-    num_batches = int(data_array.shape[1]//period)
+    num_batches = data_array.shape[1]//period
     combined=[]
     for i in range(num_batches+1):
         idx = int(period*i)
-        batch = data_array[:,idx-seq_len:idx,...]
+        batch = data_array[:,idx:idx+seq_len,...]
         combined.append(batch)
     combined = [b for b in combined if b.shape[1]==seq_len]
     combined = np.asarray(combined)

--- a/river_dl/preproc_utils.py
+++ b/river_dl/preproc_utils.py
@@ -129,17 +129,6 @@ def split_into_batches(data_array, seq_len=365, offset=1.0):
     :return: [numpy array] batched data with dims [nbatches, nseg, seq_len
     (batch_size), nfeat]
     """
-    '''
-    combined = []
-    for i in range(int(1 / offset)):
-        start = int(i * offset * seq_len)
-        idx = np.arange(start=start, stop=data_array.shape[1] + 1, step=seq_len)
-        split = np.split(data_array, indices_or_sections=idx, axis=1)
-        # add all but the first and last batch since they will be smaller
-        combined.extend([s for s in split if s.shape[1] == seq_len])
-    combined = np.asarray(combined)
-    #else:
-    '''
     if offset>1:
         period = offset
     else:

--- a/river_dl/preproc_utils.py
+++ b/river_dl/preproc_utils.py
@@ -123,11 +123,13 @@ def split_into_batches(data_array, seq_len=365, offset=1.0):
     :param data_array: [numpy array] array of training data with dims [nseg,
     ndates, nfeat]
     :param seq_len: [int] length of sequences (e.g., 365)
-    :param offset: [float] 0-1, how to offset the batches (e.g., 0.5 means that
-    the first batch will be 0-365 and the second will be 182-547)
+    :param offset: [float] How to offset the batches. Values < 1 are taken as fractions, (e.g., 0.5 means that
+    the first batch will be 0-365 and the second will be 182-547), values > 1 are used as a constant number of
+    observations to offset by.
     :return: [numpy array] batched data with dims [nbatches, nseg, seq_len
     (batch_size), nfeat]
     """
+    '''
     combined = []
     for i in range(int(1 / offset)):
         start = int(i * offset * seq_len)
@@ -135,6 +137,20 @@ def split_into_batches(data_array, seq_len=365, offset=1.0):
         split = np.split(data_array, indices_or_sections=idx, axis=1)
         # add all but the first and last batch since they will be smaller
         combined.extend([s for s in split if s.shape[1] == seq_len])
+    combined = np.asarray(combined)
+    #else:
+    '''
+    if offset>1:
+        period = offset
+    else:
+        period = int(offset*seq_len)
+    num_batches = int(data_array.shape[1]//period)
+    combined=[]
+    for i in range(num_batches+1):
+        idx = int(period*i)
+        batch = data_array[:,idx-seq_len:idx,...]
+        combined.append(batch)
+    combined = [b for b in combined if b.shape[1]==seq_len]
     combined = np.asarray(combined)
     return combined
 


### PR DESCRIPTION
This PR updates the RGCN model to work with dropout and recurrent dropout and fixes `offset` and `keep_last_frac` to do two things:
- The previous version of `split_into_batches` created gaps in train/tst/val partitions for certain `offset` values (see "wonky time series" in #152), the new version fixes that.
- You can now pass either a fraction or constant number as `offset` and `keep_last_frac`.  Values below one are taken as a fraction to keep, values > 1 are a constant number to offset by or keep at the end of the prediction sequence.