### PR TITLE
Small fixes to latest PR NA masking.

### DIFF
--- a/river_dl/preproc_utils.py
+++ b/river_dl/preproc_utils.py
@@ -131,7 +131,7 @@ def split_into_batches(data_array, seq_len=365, offset=1.0):
     (batch_size), nfeat]
     """
     if offset>1:
-        period = offset
+        period = int(offset)
     else:
         period = int(offset*seq_len)
     num_batches = data_array.shape[1]//period

--- a/river_dl/train.py
+++ b/river_dl/train.py
@@ -209,12 +209,11 @@ def train_model(
             # force the loss function focus on only the keep portion.
             if keep_portion:
                 if keep_portion > 1:
-                    period = keep_portion
+                    period = int(keep_portion)
                 else:
-                    period = int(keep_portion * y_trn_obs.shape[1])
+                    period = int(keep_portion * y_trn_pre.shape[1])
                 y_trn_pre[:, :-period, ...] = np.nan
-                y_val_pre[:, :-period, ...] = np.nan
-
+                
             # Initialize our model within the training engine
             engine = trainer(model, optimizer, loss_func)
 
@@ -256,7 +255,7 @@ def train_model(
         # force the loss function focus on only the keep portion.
         if keep_portion:
             if keep_portion > 1:
-                period = keep_portion
+                period = int(keep_portion)
             else:
                 period = int(keep_portion * y_trn_obs.shape[1])
             y_trn_obs[:,:-period,...] = np.nan


### PR DESCRIPTION
Caught some small errors in the code that masks out the non-keep portion in pretraining that was added in #154. Errors were missed because it was only tested with fine-tuning.  We were calling `y_val_pre` even though there is no validation in pre-training, and we were calling `y_trn_obs.shape` instead of `y_trn_pre.shape`