### PR TITLE
cleaning up example workflow for GW loss

### DIFF
--- a/river_dl/gw_utils.py
+++ b/river_dl/gw_utils.py
@@ -7,7 +7,6 @@ from datetime import datetime
 import math
 from itertools import compress, product
 import matplotlib.pyplot as plt
-#import seaborn as sns
 from copy import deepcopy
 
 from river_dl.preproc_utils import separate_trn_tst, read_obs, convert_batch_reshape
@@ -565,7 +564,6 @@ def calc_gw_metrics(trnFile,tstFile,valFile,outFile,figFile1, figFile2, pbm_name
                 nObs =["n: " + str(np.sum(np.isfinite(thisData[thisCol].values))) for thisCol in colsToPlot]
                 ax = fig.add_subplot(len(partDict), len(metricLst), thisFig)
                 ax.set_title('{}, {}'.format(thisMetric, thisPart))
-                #ax=sns.boxplot(data=thisData[colsToPlot])
                 ax = thisData[colsToPlot].melt().boxplot(column=['value'],by=['variable'])
                 # Add it to the plot
                 pos = range(len(nObs))

--- a/river_dl/gw_utils.py
+++ b/river_dl/gw_utils.py
@@ -565,7 +565,8 @@ def calc_gw_metrics(trnFile,tstFile,valFile,outFile,figFile1, figFile2, pbm_name
                 nObs =["n: " + str(np.sum(np.isfinite(thisData[thisCol].values))) for thisCol in colsToPlot]
                 ax = fig.add_subplot(len(partDict), len(metricLst), thisFig)
                 ax.set_title('{}, {}'.format(thisMetric, thisPart))
-                ax=sns.boxplot(data=thisData[colsToPlot])
+                #ax=sns.boxplot(data=thisData[colsToPlot])
+                ax = thisData[colsToPlot].melt().boxplot(column=['value'],by=['variable'])
                 # Add it to the plot
                 pos = range(len(nObs))
                 for tick,label in zip(pos,ax.get_xticklabels()):

--- a/river_dl/gw_utils.py
+++ b/river_dl/gw_utils.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import math
 from itertools import compress, product
 import matplotlib.pyplot as plt
-import seaborn as sns
+#import seaborn as sns
 from copy import deepcopy
 
 from river_dl.preproc_utils import separate_trn_tst, read_obs, convert_batch_reshape
@@ -60,7 +60,7 @@ def amp_phi (Date, temp, isWater=False, r_thresh=0.8, tempType="obs"):
         # this solves the regression using scikit-learn (not on the current import list), which doesn't give confidence intervals
         model = LinearRegression().fit(list(compress(x, np.isfinite(temp))),list(compress(temp, np.isfinite(temp))))
         amp = math.sqrt(model.coef_[0]**2+model.coef_[1]**2)
-        phi = math.asin(model.coef_[1]/amp)
+        phi = math.atan(model.coef_[1]/model.coef_[0])
         amp_low=np.nan
         amp_high=np.nan
         phi_low=np.nan
@@ -138,7 +138,6 @@ def annual_temp_stats(thisData, water_temp_pbm_col = 'seg_tave_water_pbm', water
     #get the phase and amplitude for air and water temps for each segment
     for i in range(len(thisData['seg_id_nat'])):
         thisSeg = thisData['seg_id_nat'][i].data
-
         waterDF = pd.DataFrame({'date':thisData['date'].values,'tave_water':thisData[water_temp_obs_col][:,i].values})
         #require temps > 1 and <60 C for signal analysis
         waterDF.loc[(waterDF.tave_water<1)|(waterDF.tave_water>60),"tave_water"]=np.nan
@@ -155,9 +154,6 @@ def annual_temp_stats(thisData, water_temp_pbm_col = 'seg_tave_water_pbm', water
         
         
         if waterSum.shape[0]>0 and thisSeg not in reservoirSegs:
-            #print(thisSeg)
-            #print(waterSum)
-            #get the air temp properties
             amp, phi, amp_low, amp_high, phi_low, phi_high = amp_phi(thisData['date'].values[thisData.waterYear.isin(waterSum.waterYear)],thisData[air_temp_col][:,i].values[thisData.waterYear.isin(waterSum.waterYear)],isWater=False)
             air_amp.append(amp)
             air_amp_low.append(amp_low)
@@ -224,7 +220,6 @@ def annual_temp_stats(thisData, water_temp_pbm_col = 'seg_tave_water_pbm', water
 
     Ar_obs = [water_amp_obs[x]/air_amp[x] for x in range(len(water_amp_obs))]
     delPhi_obs = [(air_phi[x]-water_phi_obs[x])*365/(2*math.pi) for x in range(len(water_amp_obs))]
-    
     Ar_low_obs = [water_amp_low_obs[x]/air_amp_high[x] for x in range(len(water_amp_obs))]
     Ar_high_obs = [water_amp_high_obs[x]/air_amp_low[x] for x in range(len(water_amp_obs))]
     
@@ -253,8 +248,6 @@ def annual_temp_stats(thisData, water_temp_pbm_col = 'seg_tave_water_pbm', water
     
     #reset delPhi -10 to 0
     delPhi_obs = [x if x > 0 else 0 if np.isfinite(x) else np.nan for x in delPhi_obs]
-    
-    
     
     Ar_pbm = [water_amp_pbm[x]/air_amp[x] for x in range(len(water_amp_pbm))]
     delPhi_pbm = [(air_phi[x]-water_phi_pbm[x])*365/(2*math.pi) for x in range(len(water_amp_pbm))]

--- a/workflow_examples/config_gw.yml
+++ b/workflow_examples/config_gw.yml
@@ -4,13 +4,14 @@ sntemp_file: "../river_dl/tests/test_data/test_data_seg_id_nat"
 dist_matrix_file: "../river_dl/tests/test_data/test_dist_matrix.npz"
 reach_attr_file: "../river_dl/tests/test_data/test_seg_attr_seg_id_nat.csv"
 
-out_dir: "output_DRB_offsetTest"
+out_dir: "output_test_gw"
 
 code_dir: ".."
 
-#x_vars: ["seg_rain", "seg_tave_air", "seginc_swrad", "seg_length", "seginc_potet", "seg_slope", "seg_humid", "seg_elev"]
-#x_vars: ['seg_ccov', 'seg_elev', 'seg_length', 'seg_rain', 'seg_slope', 'seg_tave_air', 'seg_tave_gw', 'seg_tave_ss', 'seg_tave_upstream', 'seg_upstream_inflow', 'seg_width', 'seginc_gwflow', 'seginc_potet', 'seginc_sroff', 'seginc_ssflow', 'seginc_swrad']
-x_vars: ['seg_slope','seg_elev','seg_width_mean','seg_tave_air','seginc_swrad','seg_rain','seginc_potet']
+
+#x_vars: ['seg_ccov', 'seg_elev', 'seg_length', 'seg_rain', 'seg_slope', 'seg_tave_air', 'seg_tave_gw', 'seg_tave_ss', 'seg_tave_upstream', 'seg_upstream_inflow', 'seg_width', 'seginc_gwflow', 'seginc_potet', 'seginc_sroff', 'seginc_ssflow', 'seginc_swrad','seg_outflow','seg_width_mean'] #full list of options
+#x_vars: ['seg_slope','seg_elev','seg_width_mean','seg_tave_air','seginc_swrad','seg_rain','seginc_potet'] #current base model variables
+x_vars: ['seg_ccov', 'seg_rain', 'seg_slope', 'seg_tave_air'] #code testing list
 
 y_vars_pretrain: ['seg_tave_water']
 y_vars_finetune: ['temp_c']
@@ -66,7 +67,9 @@ val_start_date:
 val_end_date:
   - '2010-09-30'
 
-pt_epochs: 200 
-ft_epochs: 100
+pt_epochs: 5
+ft_epochs: 5
 
 hidden_size: 20
+pretrain_learning_rate: 0.005
+finetune_learning_rate: 0.01

--- a/workflow_examples/config_gw.yml
+++ b/workflow_examples/config_gw.yml
@@ -4,6 +4,7 @@ sntemp_file: "../data_DRB/sntemp_inputs_outputs_drb_Christiana_no3558"
 dist_matrix_file: "../data_DRB/distance_matrix_drb_Christiana_no3558.npz"
 reach_attr_file: "../data_DRB/reach_attributes_drb.csv"
 
+
 out_dir: "output_test_gw"
 
 code_dir: ".."

--- a/workflow_examples/config_gw.yml
+++ b/workflow_examples/config_gw.yml
@@ -1,8 +1,8 @@
 # Input file
-obs_file: "../river_dl/tests/test_data/obs_temp_flow_seg_id_nat"
-sntemp_file: "../river_dl/tests/test_data/test_data_seg_id_nat"
-dist_matrix_file: "../river_dl/tests/test_data/test_dist_matrix.npz"
-reach_attr_file: "../river_dl/tests/test_data/test_seg_attr_seg_id_nat.csv"
+obs_file: "../data_DRB/Obs_temp_flow_drb_Christiana_no3558"
+sntemp_file: "../data_DRB/sntemp_inputs_outputs_drb_Christiana_no3558"
+dist_matrix_file: "../data_DRB/distance_matrix_drb_Christiana_no3558.npz"
+reach_attr_file: "../data_DRB/reach_attributes_drb.csv"
 
 out_dir: "output_test_gw"
 
@@ -35,37 +35,33 @@ lambdas_gw: [0.5, 0.5]
 #gw loss calculation method, either 'fft' (fourier fast transform) or 'linalg' (linear algebra)
 gw_loss_type: 'fft'
 
-#gw loss calculation method, either 'fft' (fourier fast transform) or 'linalg' (linear algebra)
-gw_loss_type: 'fft'
-
-trn_offset: 0.5 
-tst_val_offset: 0.5
+trn_offset: 1.0 
+tst_val_offset: 1.0
 
 #Define early stopping criteria, setting this to False will turn off early stopping rounds
-early_stopping: 20 
-
-#Choose whether to use the final weights from the end of training ('trained_weights') or the weights from the best
-# validation epoch ('best_val_weights')
-pred_weights: 'best_val_weights'
+early_stopping: 1 
 
 train_start_date:
   - '1984-10-01'
   - '2015-10-01'
 train_end_date:
-  - '2006-09-30'
+  - '2010-09-30'
   - '2020-09-30'
-test_start_date:
+val_start_date:
   - '1979-10-01'
   - '2010-10-01'
   - '2020-10-01'
-test_end_date:
+val_end_date:
   - '1984-09-30'
   - '2015-09-30'
   - '2021-09-30'
-val_start_date:
-  - '2006-10-01'
-val_end_date:
-  - '2010-09-30'
+test_start_date:
+  - '1980-10-01'
+  - '2020-10-01'
+test_end_date:
+  - '1985-09-30'
+  - '2021-09-30'
+
 
 pt_epochs: 5
 ft_epochs: 5
@@ -73,3 +69,4 @@ ft_epochs: 5
 hidden_size: 20
 pretrain_learning_rate: 0.005
 finetune_learning_rate: 0.01
+

--- a/workflow_examples/config_rgcn.yml
+++ b/workflow_examples/config_rgcn.yml
@@ -8,7 +8,7 @@ code_dir: ".."
 #### for flow modeling, seg_width should be removed from x_vars
 x_vars: ['seg_ccov', 'seg_rain', 'seg_slope', 'seg_tave_air']
 
-out_dir: "output_test"
+out_dir: "output_test_rgcn"
 
 seed: False #random seed for training False==No seed, otherwise specify the seed
 


### PR DESCRIPTION
This cleans up and fixes some errors in the example workflow for the GW loss. In particular, it removes the dependencies on the StatsModels and Seaborn packages. 

The test data for this workflow is the data for the Christiana. I got errors with the rgcn test data, I suspect b/c that doesn't included segments / times for which we can calculate the gw loss, though I didn't actually test that.