### PR TITLE
adding determinism settings for the pytorch models

### DIFF
--- a/river_dl/torch_models.py
+++ b/river_dl/torch_models.py
@@ -8,7 +8,7 @@ import torch.nn.functional as F
 class RGCN_v0(nn.Module):
 
     # Built off of https://towardsdatascience.com/building-a-lstm-by-hand-on-pytorch-59c02a4ec091
-    def __init__(self, input_dim, hidden_dim, adj_matrix, recur_dropout=0, dropout=0, return_states=False, device='cpu'):
+    def __init__(self, input_dim, hidden_dim, adj_matrix, recur_dropout=0, dropout=0, return_states=False, device='cpu', seed = None):
         """
         @param input_dim: [int] number input feature
         @param hidden_dim: [int] hidden size
@@ -17,6 +17,14 @@ class RGCN_v0(nn.Module):
         @param dropout: [float] fraction of the units to drop from the input
         @param return_states: [bool] If true, returns h and c states as well as predictions
         """
+
+        if seed:
+            torch.manual_seed(seed)
+            torch.cuda.manual_seed(seed)
+            torch.backends.cudnn.deterministic = True
+            torch.backends.cudnn.benchmark = False
+
+
         super().__init__()
 
         # New stuff
@@ -102,7 +110,7 @@ class RGCN_v0(nn.Module):
 # https://doi.org/10.1137/1.9781611976700.69
 class RGCN_v1(nn.Module):
     # Built off of https://towardsdatascience.com/building-a-lstm-by-hand-on-pytorch-59c02a4ec091
-    def __init__(self, input_dim, hidden_dim, adj_matrix, recur_dropout=0, dropout=0, return_states=False, device='cpu'):
+    def __init__(self, input_dim, hidden_dim, adj_matrix, recur_dropout=0, dropout=0, return_states=False, device='cpu', seed=None):
         """
         @param input_dim: [int] number input feature
         @param hidden_dim: [int] hidden size
@@ -111,6 +119,14 @@ class RGCN_v1(nn.Module):
         @param dropout: [float] fraction of the units to drop from the input
         @param return_states: [bool] If true, returns h and c states as well as predictions
         """
+        if seed:
+            torch.manual_seed(seed)
+            torch.cuda.manual_seed(seed)
+            torch.backends.cudnn.deterministic = True
+            torch.backends.cudnn.benchmark = False
+
+
+
         super().__init__()
 
         # New stuff
@@ -181,7 +197,14 @@ def nconv(x, A):
     return torch.einsum('ncvl,vw->ncwl', (x, A)).contiguous()
 
 class GraphConvNet(nn.Module):
-    def __init__(self, c_in, c_out, dropout, support_len=3, order=2):
+    def __init__(self, c_in, c_out, dropout, support_len=3, order=2, seed = None):
+
+        if seed:
+            torch.manual_seed(seed)
+            torch.cuda.manual_seed(seed)
+            torch.backends.cudnn.deterministic = True
+            torch.backends.cudnn.benchmark = False
+
         super().__init__()
         c_in = (order * support_len + 1) * c_in
         self.final_conv = Conv2d(c_in, c_out, (1, 1), padding=(0, 0), stride=(1, 1), bias=True)
@@ -209,7 +232,17 @@ class gwnet(nn.Module):
                  addaptadj=True, aptinit=None, in_dim=2, out_dim=12,
                  residual_channels=32, dilation_channels=32,
                  skip_channels=256, end_channels=512, kernel_size=2, blocks=4, layers=2,
-                 apt_size=10, cat_feat_gc=False):
+                 apt_size=10, cat_feat_gc=False, seed = None):
+
+
+        if seed:
+            torch.manual_seed(seed)
+            torch.cuda.manual_seed(seed)
+            torch.backends.cudnn.deterministic = True
+            torch.backends.cudnn.benchmark = False
+
+
+
         super().__init__()
         self.dropout = dropout
         self.blocks = blocks

--- a/river_dl/torch_utils.py
+++ b/river_dl/torch_utils.py
@@ -379,7 +379,7 @@ def GW_loss_prep(temp_index, data, y_pred, temp_mean, temp_sd, gw_mean, gw_std, 
         #Ar_pred = the ratio of the water temp and air temp amplitudes
         Ar_pred = (Aw/A_air-gw_mean[0])/gw_std[0]
         y_pred_temp = torch.squeeze(y_pred_temp)
-        y_pred_mean = y_pred_mean = torch.mean(y_pred_temp, 1, keepdims=True)
+        y_pred_mean = torch.mean(y_pred_temp, 1, keepdims=True)
 
     #scale the predicted mean temp
     Tmean_pred = torch.squeeze((y_pred_mean-gw_mean[2])/gw_std[2])

--- a/river_dl/torch_utils.py
+++ b/river_dl/torch_utils.py
@@ -5,7 +5,7 @@ import pandas as pd
 import time
 from tqdm import tqdm
 import math as m
-
+import os
 
 def reshape_for_gwn(cat_data, keep_portion=None):
     """
@@ -120,6 +120,7 @@ def train_torch(model,
                 weights_file = None,
                 log_file= None,
                 device = 'cpu',
+                seed = None,
                 keep_portion = None):
     """
     @param model: [objetct] initialized torch model
@@ -133,6 +134,14 @@ def train_torch(model,
     @param log_file: [str] path to save training log to
     @return: [object] trained model
     """
+
+    if seed:
+        os.environ["PYTHONHASHSEED"] = str(seed)
+        torch.manual_seed(seed)
+        torch.cuda.manual_seed(seed)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+        np.random.seed(seed)
 
     print(f"Training on {device}")
     print("start training...",flush=True)

--- a/river_dl/torch_utils.py
+++ b/river_dl/torch_utils.py
@@ -120,7 +120,6 @@ def train_torch(model,
                 weights_file = None,
                 log_file= None,
                 device = 'cpu',
-                seed = None,
                 keep_portion = None):
     """
     @param model: [objetct] initialized torch model
@@ -135,13 +134,6 @@ def train_torch(model,
     @return: [object] trained model
     """
 
-    if seed:
-        os.environ["PYTHONHASHSEED"] = str(seed)
-        torch.manual_seed(seed)
-        torch.cuda.manual_seed(seed)
-        torch.backends.cudnn.deterministic = True
-        torch.backends.cudnn.benchmark = False
-        np.random.seed(seed)
 
     print(f"Training on {device}")
     print("start training...",flush=True)

--- a/river_dl/torch_utils.py
+++ b/river_dl/torch_utils.py
@@ -5,7 +5,6 @@ import pandas as pd
 import time
 from tqdm import tqdm
 import math as m
-import os
 
 def reshape_for_gwn(cat_data, keep_portion=None):
     """

--- a/river_dl/torch_utils.py
+++ b/river_dl/torch_utils.py
@@ -370,7 +370,7 @@ def GW_loss_prep(temp_index, data, y_pred, temp_mean, temp_sd, gw_mean, gw_std, 
         #Ar_pred = the ratio of the water temp and air temp amplitudes
         Ar_pred = (Aw/A_air-gw_mean[0])/gw_std[0]
         y_pred_temp = torch.squeeze(y_pred_temp)
-        y_pred_mean = torch.mean(y_pred_temp, 1, keepdims=True)
+        y_pred_mean = y_pred_mean = torch.mean(y_pred_temp, 1, keepdims=True)
 
     #scale the predicted mean temp
     Tmean_pred = torch.squeeze((y_pred_mean-gw_mean[2])/gw_std[2])

--- a/workflow_examples/Snakefile_gw_pytorch.smk
+++ b/workflow_examples/Snakefile_gw_pytorch.smk
@@ -109,7 +109,7 @@ rule finetune_train:
         adj_mx = data['dist_matrix']
         in_dim = len(data['x_vars'])
         device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
-        model = RGCN_v1(in_dim,config['hidden_size'],adj_mx,device=device)
+        model = RGCN_v1(in_dim,config['hidden_size'],adj_mx,device=device, seed=config['seed'])
         opt = optim.Adam(model.parameters(),lr=config['finetune_learning_rate'])
         model.load_state_dict(torch.load(input[1]))
         train_torch(model,
@@ -124,6 +124,7 @@ rule finetune_train:
             batch_size = num_segs,
             weights_file=output[0],
             log_file=output[1],
+            seed = config['seed'],
             device=device)
 
 

--- a/workflow_examples/Snakefile_gw_pytorch.smk
+++ b/workflow_examples/Snakefile_gw_pytorch.smk
@@ -124,7 +124,6 @@ rule finetune_train:
             batch_size = num_segs,
             weights_file=output[0],
             log_file=output[1],
-            seed = config['seed'],
             device=device)
 
 

--- a/workflow_examples/Snakefile_rgcn_pytorch.smk
+++ b/workflow_examples/Snakefile_rgcn_pytorch.smk
@@ -103,7 +103,6 @@ rule pre_train:
                     batch_size = num_segs,
                     weights_file = output[0],
                     log_file = output[1],
-                    seed = config['seed'],
                     device=device)
 
 
@@ -138,7 +137,6 @@ rule finetune_train:
             batch_size = num_segs,
             weights_file=output[0],
             log_file=output[1],
-            seed = config['seed'],
             device=device)
 
 

--- a/workflow_examples/Snakefile_rgcn_pytorch.smk
+++ b/workflow_examples/Snakefile_rgcn_pytorch.smk
@@ -91,7 +91,7 @@ rule pre_train:
         adj_mx = data['dist_matrix']
         in_dim = len(data['x_vars'])
         device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
-        model = RGCN_v1(in_dim, config['hidden_size'], adj_mx,device=device)
+        model = RGCN_v1(in_dim, config['hidden_size'], adj_mx,device=device, seed=config['seed'])
         opt = optim.Adam(model.parameters(),lr=config['pretrain_learning_rate'])
         train_torch(model,
                     loss_function = rmse_masked,
@@ -103,6 +103,7 @@ rule pre_train:
                     batch_size = num_segs,
                     weights_file = output[0],
                     log_file = output[1],
+                    seed = config['seed'],
                     device=device)
 
 
@@ -121,7 +122,7 @@ rule finetune_train:
         adj_mx = data['dist_matrix']
         in_dim = len(data['x_vars'])
         device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
-        model = RGCN_v1(in_dim,config['hidden_size'],adj_mx,device=device)
+        model = RGCN_v1(in_dim,config['hidden_size'],adj_mx,device=device, seed=config['seed'])
         opt = optim.Adam(model.parameters(),lr=config['finetune_learning_rate'])
         scheduler = optim.lr_scheduler.LambdaLR(opt,lr_lambda=lambda epoch: 0.97 ** epoch)
         model.load_state_dict(torch.load(input[1]))
@@ -137,6 +138,7 @@ rule finetune_train:
             batch_size = num_segs,
             weights_file=output[0],
             log_file=output[1],
+            seed = config['seed'],
             device=device)
 
 


### PR DESCRIPTION
This PR passes the seed from the config file to pytorch models to allow deterministic training. Unlike with TF, the torch models need to have the seed passed to both the model function and the train function. I added this functionality to all 4 torch models, but I only tested it with RGCN_v1.