### PR TITLE
More flexible combined metrics 

### DIFF
--- a/river_dl/evaluate.py
+++ b/river_dl/evaluate.py
@@ -197,6 +197,7 @@ def partition_metrics(
         spatial_idx_name="seg_id_nat",
         time_idx_name="date",
         group=None,
+        id_dict=None,
         outfile=None
 ):
     """
@@ -213,6 +214,9 @@ def partition_metrics(
     Currently only supports 'seg_id_nat' (segment-wise metrics), 'month'
     (month-wise metrics), ['seg_id_nat', 'month'] (metrics broken out by segment
     and month), and None (everything is left together)
+    :param id_dict: [dict] dictionary of id_dict where dict keys are the id
+    names and dict values are the id values. These are added as columns to the
+    metrics information
     :param outfile: [str] file where the metrics should be written
     :return: [pd dataframe] the condensed metrics
     """
@@ -249,6 +253,9 @@ def partition_metrics(
 
         metrics["variable"] = data_var
         metrics["partition"] = partition
+        if id_dict:
+            for id_name, id_val in id_dict.items():
+                metrics[id_name] = id_val
         var_metrics_list.append(metrics)
         var_metrics = pd.concat(var_metrics_list).round(6)
     if outfile:
@@ -264,6 +271,7 @@ def combined_metrics(
     spatial_idx_name="seg_id_nat",
     time_idx_name="date",
     group=None,
+    id_dict=None,
     outfile=None,
 ):
     """
@@ -281,6 +289,9 @@ def combined_metrics(
     Currently only supports 'seg_id_nat' (segment-wise metrics), 'month'
     (month-wise metrics), ['seg_id_nat', 'month'] (metrics broken out by segment
     and month), and None (everything is left together)
+    :param id_dict: [dict] dictionary of id_dict where dict keys are the id
+    names and dict values are the id values. These are added as columns to the
+    metrics information
     :param outfile: [str] csv file where the metrics should be written
     :return: combined metrics
     """
@@ -291,6 +302,7 @@ def combined_metrics(
                                         partition="trn",
                                         spatial_idx_name=spatial_idx_name,
                                         time_idx_name=time_idx_name,
+                                        id_dict=id_dict,
                                         group=group)
         df_all.extend([trn_metrics])
     if pred_val:
@@ -299,6 +311,7 @@ def combined_metrics(
                                         partition="val",
                                         spatial_idx_name=spatial_idx_name,
                                         time_idx_name=time_idx_name,
+                                        id_dict=id_dict,
                                         group=group)
         df_all.extend([val_metrics])
     if pred_tst:
@@ -307,6 +320,7 @@ def combined_metrics(
                                         partition="tst",
                                         spatial_idx_name=spatial_idx_name,
                                         time_idx_name=time_idx_name,
+                                        id_dict=id_dict,
                                         group=group)
         df_all.extend([tst_metrics])
     df_all = pd.concat(df_all, axis=0)

--- a/river_dl/evaluate.py
+++ b/river_dl/evaluate.py
@@ -191,7 +191,7 @@ def calc_metrics(df):
 
 
 def partition_metrics(
-        pred_file,
+        preds,
         obs_file,
         partition,
         spatial_idx_name="seg_id_nat",
@@ -203,7 +203,8 @@ def partition_metrics(
     """
     calculate metrics for a certain group (or no group at all) for a given
     partition and variable
-    :param pred_file: [str] path to predictions feather file
+    :param preds: [str or DataFrame] path to predictions feather file or Pandas
+    DataFrame of predictions
     :param obs_file: [str] path to observations zarr file
     :param partition: [str] data partition for which metrics are calculated
     :param spatial_idx_name: [str] name of column that is used for spatial
@@ -220,7 +221,7 @@ def partition_metrics(
     :param outfile: [str] file where the metrics should be written
     :return: [pd dataframe] the condensed metrics
     """
-    var_data = fmt_preds_obs(pred_file, obs_file, spatial_idx_name,
+    var_data = fmt_preds_obs(preds, obs_file, spatial_idx_name,
                              time_idx_name)
     var_metrics_list = []
 
@@ -280,11 +281,15 @@ def combined_metrics(
     given grouping
     :param obs_file: [str] path to observations zarr file
     :param pred_data: [dict] dict where keys are partition labels and values 
-    are the corresponding prediction data file. If this is provided, this will
-    be used and none of pred_trn, pred_val, or pred_tst will be used.
-    :param pred_trn: [str] path to training prediction feather file
-    :param pred_val: [str] path to validation prediction feather file
-    :param pred_tst: [str] path to testing prediction feather file
+    are the corresponding prediction data file or predictions as a pandas
+    dataframe. If pred_data is provided, this will be used and none of
+    pred_trn, pred_val, or pred_tst will be used.
+    :param pred_trn: [str or DataFrame] path to training prediction feather file
+    or training predictions as pandas dataframe
+    :param pred_val: [str or DataFrame] path to validation prediction feather
+    file or validation predictions as pandas dataframe
+    :param pred_tst: [str or DataFrame] path to testing prediction feather file
+    or test predictions as pandas dataframe
     :param spatial_idx_name: [str] name of column that is used for spatial
         index (e.g., 'seg_id_nat')
     :param time_idx_name: [str] name of column that is used for temporal index
@@ -317,8 +322,8 @@ def combined_metrics(
         raise KeyError("No prediction data was provided")
 
     df_all = []
-    for partition, pred_file in pred_data.items():
-        metrics = partition_metrics(pred_file=pred_file,
+    for partition, preds in pred_data.items():
+        metrics = partition_metrics(preds=preds,
                                     obs_file=obs_file,
                                     partition=partition,
                                     spatial_idx_name=spatial_idx_name,

--- a/river_dl/tests/test_evaluate.py
+++ b/river_dl/tests/test_evaluate.py
@@ -1,0 +1,75 @@
+import numpy as np
+import pytest
+import pandas as pd
+import xarray as xr
+from river_dl import evaluate as ev
+
+
+def get_partition_nse(df, partition):
+    return df.query(f"partition == '{partition}'")['nse'].values[0]
+
+def test_pred_data():
+    obs_file = "test_data/obs_temp_flow"
+    obs_ds = xr.open_zarr(obs_file)
+    obs_df = obs_ds.to_dataframe()
+    metrics = ev.combined_metrics(obs_file = obs_file,
+                                  pred_data = {"trn": obs_df,
+                                               "val": obs_df,
+                                               "tst": obs_df},
+                                  spatial_idx_name="segs_test",
+                                  time_idx_name="times_test")
+    assert get_partition_nse(metrics, 'trn') == 1
+    assert get_partition_nse(metrics, 'val') == 1
+    assert get_partition_nse(metrics, 'tst') == 1
+
+
+def test_pred_data_no_val():
+    obs_file = "test_data/obs_temp_flow"
+    obs_ds = xr.open_zarr(obs_file)
+    obs_df = obs_ds.to_dataframe()
+    metrics = ev.combined_metrics(obs_file = obs_file,
+                                  pred_data = {"trn": obs_df,
+                                               "tst": obs_df},
+                                  spatial_idx_name="segs_test",
+                                  time_idx_name="times_test")
+    assert get_partition_nse(metrics, 'trn') == 1
+    assert get_partition_nse(metrics, 'tst') == 1
+
+    with pytest.raises(IndexError):
+        get_partition_nse(metrics, 'val') == 1
+
+
+def test_pred_data_prd_val():
+    obs_file = "test_data/obs_temp_flow"
+    obs_ds = xr.open_zarr(obs_file)
+    obs_df = obs_ds.to_dataframe()
+    metrics = ev.combined_metrics(obs_file = obs_file,
+                                  pred_data = {"trn": obs_df,
+                                               "tst": obs_df},
+                                  pred_val = obs_df,
+                                  spatial_idx_name="segs_test",
+                                  time_idx_name="times_test")
+    assert get_partition_nse(metrics, 'trn') == 1
+    assert get_partition_nse(metrics, 'tst') == 1
+
+    with pytest.raises(IndexError):
+        get_partition_nse(metrics, 'val') == 1
+
+
+def test_id_dict():
+    obs_file = "test_data/obs_temp_flow"
+    obs_ds = xr.open_zarr(obs_file)
+    obs_df = obs_ds.to_dataframe()
+    metrics = ev.combined_metrics(obs_file = obs_file,
+                                  pred_data = {"trn": obs_df,
+                                               "tst": obs_df},
+                                  spatial_idx_name="segs_test",
+                                  time_idx_name="times_test",
+                                  id_dict={"run_id":4,
+                                            "exp_id": "giz"}
+                                  )
+    assert "run_id" in metrics.columns
+    assert "exp_id" in metrics.columns
+
+    assert np.sum(metrics['run_id'].values != 4) == 0
+    assert np.sum(metrics['exp_id'].values != "giz") == 0

--- a/river_dl/tests/test_loss_functions.py
+++ b/river_dl/tests/test_loss_functions.py
@@ -1,21 +1,21 @@
 import numpy as np
 import pandas as pd
-from river_dl.loss_functions import rmse_masked, nse
+from river_dl.loss_functions import rmse, nse
 
 
 def test_rmse_masked():
     y_true = pd.Series([1, 5, 3, 4, 2])
     y_pred = y_true.copy()
-    err = rmse_masked(y_true, y_pred)
+    err = rmse(y_true, y_pred)
     assert err == 0
 
     y_pred = pd.Series([0, 0, 0, 0, 0])
-    err = rmse_masked(y_true, y_pred)
-    assert round(err, 2) == 3.32
+    err = rmse(y_true, y_pred)
+    assert round(float(err.numpy()), 2) == 3.32
 
     y_true = pd.Series([1, np.nan, 3, 4, 2])
-    err = rmse_masked(y_true, y_pred)
-    assert round(err, 2) == 2.74
+    err = rmse(y_true, y_pred)
+    assert round(float(err.numpy()), 2) == 2.74
 
 
 def test_nse():
@@ -30,21 +30,21 @@ def test_nse():
 
     y_pred = pd.Series([2, 4, 0, 4, 2])
     nse_samp = nse(y_true, y_pred)
-    assert round(nse_samp, 1) == -0.1
+    assert round(float(nse_samp.numpy()), 1) == -0.1
 
     y_pred = pd.Series([1, 4, 2, 4, 2])
     nse_samp = nse(y_true, y_pred)
-    assert round(nse_samp, 1) == 0.8
+    assert round(float(nse_samp.numpy()), 1) == 0.8
 
     y_true = pd.Series([1, np.nan, 3, 4, 2])
     y_pred = pd.Series([1, 4, 2, 4, 2])
     nse_samp = nse(y_true, y_pred)
-    assert round(nse_samp, 1) == 0.8
+    assert round(float(nse_samp.numpy()), 1) == 0.8
 
     y_true = pd.Series([1, np.nan, 3, 4, np.nan])
     y_pred = pd.Series([1, 4, 2, 4, 2])
     nse_samp = nse(y_true, y_pred)
-    assert round(nse_samp, 2) == 0.79
+    assert round(float(nse_samp.numpy()), 2) == 0.79
 
     y_true = pd.Series([1, np.nan, 2, 4, np.nan])
     y_pred = pd.Series([1, 4, 2, 4, 2])

--- a/river_dl/tests/test_loss_functions.py
+++ b/river_dl/tests/test_loss_functions.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from postproc_utils import rmse_masked, nse
+from river_dl.loss_functions import rmse_masked, nse
 
 
 def test_rmse_masked():


### PR DESCRIPTION
This PR makes two main changes in the `combined_metrics` function. 
1. it allows the user to provide any list of arbitrary ids to distinguish metrics files
2. it allows the user to pass any number of prediction datasets with any labels to `combine_metrics` instead of only `pred_trn`, `pred_val`, and `pred_tst`

closes #183
closes #184