### PR TITLE
Minor edits to GW loss

### DIFF
--- a/river_dl/gw_utils.py
+++ b/river_dl/gw_utils.py
@@ -406,10 +406,10 @@ def calc_amp_phi(thisData, water_temp_pred_col = "temp_c", tempType="pred"):
     water_phi_preds = []
     water_mean_preds = []
     for thisSeg in segList:
-        amp, phi, amp_low, amp_high, phi_low, phi_high = amp_phi(thisData.loc[thisData.seg_id_nat==thisSeg,"date"].values,thisData.loc[thisData.seg_id_nat==thisSeg,water_temp_pred_col],isWater=True, tempType = tempType)
+        amp, phi, amp_low, amp_high, phi_low, phi_high, Tmean = amp_phi(thisData.loc[thisData.seg_id_nat==thisSeg,"date"].values,thisData.loc[thisData.seg_id_nat==thisSeg,water_temp_pred_col],isWater=True, tempType = tempType)
         water_amp_preds.append(amp)
         water_phi_preds.append(phi)
-        water_mean_preds.append(np.nanmean(thisData.loc[thisData.seg_id_nat==thisSeg,water_temp_pred_col]))
+        water_mean_preds.append(Tmean)
     return pd.DataFrame({'seg_id_nat':segList,'water_amp_pred':water_amp_preds,'water_phi_pred':water_phi_preds, 'Tmean_pred':water_mean_preds})
 
 def make_decimal_date(date, ref_date = "1980-10-01"):

--- a/river_dl/gw_utils.py
+++ b/river_dl/gw_utils.py
@@ -331,7 +331,7 @@ def prep_annual_signal_data(
         reservoirSegs = reachDF.seg_id_nat.loc[reachDF.reach_class.isin(['contains_reservoir','downstream of reservoir (1)','downstream of reservoir (2)','reservoir_inlet_reach','reservoir_outlet_reach','within_reservoir'])].values
         #seg_id_nat isn't included in the reservoir csv as of 1/6/2022
         if extraResSegments:
-            reservoirSegs = np.append(reservoirSegs,extraResSegment)
+            reservoirSegs = np.append(reservoirSegs,extraResSegments)
 
     else:
         reservoirSegs = []

--- a/river_dl/gw_utils.py
+++ b/river_dl/gw_utils.py
@@ -195,7 +195,7 @@ def annual_temp_stats(thisData, water_temp_pbm_col = 'seg_tave_water_pbm', water
                     #    waterDF = waterDF.loc[waterDF.bin==maxBin]
 
             amp, phi, amp_low, amp_high, phi_low, phi_high, Tmean = amp_phi(waterDF.date.values,waterDF.tave_water.values,isWater=True)
-            meanTemp = Tmean)
+            meanTemp = Tmean
 
         else:
             amp, phi, amp_low, amp_high, phi_low, phi_high, Tmean = amp_phi(thisData['date'].values,thisData[air_temp_col][:,i].values,isWater=False)

--- a/river_dl/gw_utils.py
+++ b/river_dl/gw_utils.py
@@ -39,8 +39,8 @@ def amp_phi (Date, temp, isWater=False, r_thresh=0.8, tempType="obs"):
     
     #remove water temps below 1C or above 45C to avoid complex freeze-thaw dynamics near 0 C and because >45C is likely erroneous  
     if isWater:
-        temp = [x if x >=1 and x<=45 else np.nan for x in temp]
-    
+        #temp = [x if x >=1 and x<=45 else np.nan for x in temp]
+        temp = [x if x>=1 else 1 for x in temp]
     x = [[math.sin(2*math.pi*j),math.cos(2*math.pi*j)] for j in date_decimal]
     
 

--- a/river_dl/gw_utils.py
+++ b/river_dl/gw_utils.py
@@ -60,6 +60,7 @@ def amp_phi (Date, temp, isWater=False, r_thresh=0.8, tempType="obs"):
         model = LinearRegression().fit(list(compress(x, np.isfinite(temp))),list(compress(temp, np.isfinite(temp))))
         amp = math.sqrt(model.coef_[0]**2+model.coef_[1]**2)
         phi = math.atan(model.coef_[1]/model.coef_[0])
+        Tmean = np.nanmean(temp)
         amp_low=np.nan
         amp_high=np.nan
         phi_low=np.nan
@@ -98,8 +99,9 @@ def amp_phi (Date, temp, isWater=False, r_thresh=0.8, tempType="obs"):
         amp_high=np.nan
         phi_low=np.nan
         phi_high = np.nan
+        Tmean = np.nan
     
-    return amp, phi, amp_low, amp_high, phi_low, phi_high
+    return amp, phi, amp_low, amp_high, phi_low, phi_high, Tmean
 
 
 def annual_temp_stats(thisData, water_temp_pbm_col = 'seg_tave_water_pbm', water_temp_obs_col="seg_tave_water",air_temp_col = 'seg_tave_air', reservoirSegs = []):
@@ -141,7 +143,7 @@ def annual_temp_stats(thisData, water_temp_pbm_col = 'seg_tave_water_pbm', water
         thisSeg = thisData['seg_id_nat'][i].data
         waterDF = pd.DataFrame({'date':thisData['date'].values,'tave_water':thisData[water_temp_obs_col][:,i].values})
         #require temps > 1 and <60 C for signal analysis
-        waterDF.loc[(waterDF.tave_water<1)|(waterDF.tave_water>60),"tave_water"]=np.nan
+        waterDF.loc[(waterDF.tave_water<1),"tave_water"]=1
         waterDF.dropna(inplace=True)
         waterDF['waterYear']=waterDF['date'].dt.year 
         waterDF.loc[waterDF['date'].dt.month>=10,"waterYear"]= waterDF.loc[waterDF['date'].dt.month>=10,'date'].dt.year+1
@@ -155,7 +157,7 @@ def annual_temp_stats(thisData, water_temp_pbm_col = 'seg_tave_water_pbm', water
         
         
         if waterSum.shape[0]>0 and thisSeg not in reservoirSegs:
-            amp, phi, amp_low, amp_high, phi_low, phi_high = amp_phi(thisData['date'].values[thisData.waterYear.isin(waterSum.waterYear)],thisData[air_temp_col][:,i].values[thisData.waterYear.isin(waterSum.waterYear)],isWater=False)
+            amp, phi, amp_low, amp_high, phi_low, phi_high, Tmean = amp_phi(thisData['date'].values[thisData.waterYear.isin(waterSum.waterYear)],thisData[air_temp_col][:,i].values[thisData.waterYear.isin(waterSum.waterYear)],isWater=False)
             air_amp.append(amp)
             air_amp_low.append(amp_low)
             air_amp_high.append(amp_high)
@@ -164,14 +166,14 @@ def annual_temp_stats(thisData, water_temp_pbm_col = 'seg_tave_water_pbm', water
             air_phi_high.append(phi_high)
 
             #get the process-based model (pbm) water temp properties
-            amp, phi, amp_low, amp_high, phi_low, phi_high = amp_phi(thisData['date'].values[thisData.waterYear.isin(waterSum.waterYear)],thisData[water_temp_pbm_col][:,i].values[thisData.waterYear.isin(waterSum.waterYear)],isWater=True)
+            amp, phi, amp_low, amp_high, phi_low, phi_high, Tmean = amp_phi(thisData['date'].values[thisData.waterYear.isin(waterSum.waterYear)],thisData[water_temp_pbm_col][:,i].values[thisData.waterYear.isin(waterSum.waterYear)],isWater=True)
             water_amp_pbm.append(amp)
             water_amp_low_pbm.append(amp_low)
             water_amp_high_pbm.append(amp_high)
             water_phi_pbm.append(phi)
             water_phi_low_pbm.append(phi_low)
             water_phi_high_pbm.append(phi_high)
-            water_mean_pbm.append(np.nanmean(thisData[water_temp_pbm_col][:,i].values[thisData.waterYear.isin(waterSum.waterYear)]))
+            water_mean_pbm.append(Tmean)
 
 
             #get the observed water temp properties
@@ -192,11 +194,11 @@ def annual_temp_stats(thisData, water_temp_pbm_col = 'seg_tave_water_pbm', water
                     #    maxBin = waterSum.bin[waterSum.date==np.max(waterSum.date)].values[0]
                     #    waterDF = waterDF.loc[waterDF.bin==maxBin]
 
-            amp, phi, amp_low, amp_high, phi_low, phi_high = amp_phi(waterDF.date.values,waterDF.tave_water.values,isWater=True)
-            meanTemp = np.nanmean(waterDF.tave_water.values)
+            amp, phi, amp_low, amp_high, phi_low, phi_high, Tmean = amp_phi(waterDF.date.values,waterDF.tave_water.values,isWater=True)
+            meanTemp = Tmean)
 
         else:
-            amp, phi, amp_low, amp_high, phi_low, phi_high = amp_phi(thisData['date'].values,thisData[air_temp_col][:,i].values,isWater=False)
+            amp, phi, amp_low, amp_high, phi_low, phi_high, Tmean = amp_phi(thisData['date'].values,thisData[air_temp_col][:,i].values,isWater=False)
             air_amp.append(amp)
             air_amp_low.append(amp_low)
             air_amp_high.append(amp_high)

--- a/river_dl/gw_utils.py
+++ b/river_dl/gw_utils.py
@@ -279,6 +279,7 @@ def prep_annual_signal_data(
     water_temp_obs_col = 'temp_c',
     segs = None,
     reach_file = None,
+    extraResSegments = None,
     gw_loss_type = 'fft',
     trn_offset = 1,
     tst_val_offset = 1
@@ -327,7 +328,8 @@ def prep_annual_signal_data(
         reachDF = pd.read_csv(reach_file)
         reservoirSegs = reachDF.seg_id_nat.loc[reachDF.reach_class.isin(['contains_reservoir','downstream of reservoir (1)','downstream of reservoir (2)','reservoir_inlet_reach','reservoir_outlet_reach','within_reservoir'])].values
         #seg_id_nat isn't included in the reservoir csv as of 1/6/2022
-        reservoirSegs = np.append(reservoirSegs,2005)
+        if extraResSegments:
+            reservoirSegs = np.append(reservoirSegs,extraResSegment)
 
     else:
         reservoirSegs = []

--- a/river_dl/loss_functions.py
+++ b/river_dl/loss_functions.py
@@ -213,6 +213,10 @@ def GW_loss_prep(temp_index, data, y_pred, temp_mean, temp_sd, gw_mean, gw_std, 
     y_pred_temp = y_pred_temp * temp_sd + temp_mean
     y_true_temp = y_true_temp * temp_sd + temp_mean
     
+    #set temps < 1 to 1
+    y_pred_temp[y_pred_temp<1]=1
+    y_true_temp[y_true_temp<1]=1
+ 
     Ar_obs = y_true[:, 0, 0]
     delPhi_obs = y_true[:, 0, 1]
     Tmean_obs = y_true[:, 0, 2]

--- a/river_dl/torch_utils.py
+++ b/river_dl/torch_utils.py
@@ -304,6 +304,10 @@ def GW_loss_prep(temp_index, data, y_pred, temp_mean, temp_sd, gw_mean, gw_std, 
     # unscale the predicted temps prior to calculating the amplitude and phase
     y_pred_temp = y_pred_temp * temp_sd + temp_mean
     y_true_temp = y_true_temp * temp_sd + temp_mean
+
+    #set temps < 1 to 1
+    y_pred_temp[y_pred_temp<1]=1
+    y_true_temp[y_true_temp<1]=1
     
     Ar_obs = y_true[:, 0, 0]
     delPhi_obs = y_true[:, 0, 1]

--- a/workflow_examples/Snakefile_gw.smk
+++ b/workflow_examples/Snakefile_gw.smk
@@ -65,6 +65,7 @@ rule prep_ann_temp:
                   test_start_date=config['test_start_date'],
                   test_end_date=config['test_end_date'], 
                   out_file=output[0],
+                  extraResSegments = config['extraResSegments'],
                   reach_file= config['reach_attr_file'],
                   gw_loss_type=config['gw_loss_type'],
                   trn_offset = config['trn_offset'],

--- a/workflow_examples/Snakefile_gw_pytorch.smk
+++ b/workflow_examples/Snakefile_gw_pytorch.smk
@@ -65,6 +65,7 @@ rule prep_ann_temp:
                   test_start_date=config['test_start_date'],
                   test_end_date=config['test_end_date'], 
                   out_file=output[0],
+                  extraResSegments = config['extraResSegments'],
                   reach_file= config['reach_attr_file'],
                   gw_loss_type=config['gw_loss_type'],
                   trn_offset = config['trn_offset'],

--- a/workflow_examples/config_gw.yml
+++ b/workflow_examples/config_gw.yml
@@ -21,6 +21,8 @@ y_vars_finetune: ['temp_c']
 #y_vars_pretrain: ['seg_tave_water', 'seg_outflow']^M
 ##y_vars_finetune: ['temp_c', 'discharge_cms']^M
 
+extraResSegments: [2005,1565,1571] #segments influenced by reservoirs that aren't included in the reach attributes list
+
 seed: 1234 #random seed for training False==No seed, otherwise specify the seed
 dropout: 0
 recurrent_dropout: 0.3

--- a/workflow_examples/config_gw_pytorch.yml
+++ b/workflow_examples/config_gw_pytorch.yml
@@ -19,6 +19,8 @@ y_vars_finetune: ['temp_c']
 #y_vars_pretrain: ['seg_tave_water', 'seg_outflow']^M
 ##y_vars_finetune: ['temp_c', 'discharge_cms']^M
 
+extraResSegments: [2005,1565,1571] #segments influenced by reservoirs that aren't included in the reach attributes list
+
 seed: 1234 #random seed for training False==No seed, otherwise specify the seed
 dropout: 0
 recurrent_dropout: 0.3


### PR DESCRIPTION
This PR makes 2 relatively minor updates to the GW loss code. 

1. It moves the list of additional reservoir-affected reaches (that aren't in the reach attributes file) out of the gw_utils.py and into the config file
2. It standardizes treatment of temps < 1 C in the annual stats calculations. Previously they were dropped in the calculations of the targets (to avoid freeze / thaw dynamics) and included in the calculations within the loss function (because the fft doesn't play nicely with missing values). Now temps < 1 are set to 1 in both locations. Setting the temps < 1 to 1 resulted in stats that more closely matched the results when they were removed than did leaving them in or setting temps < 0 to 0. 
