### PR TITLE
Specify train sites to remove from test metrics

### DIFF
--- a/river_dl/evaluate.py
+++ b/river_dl/evaluate.py
@@ -201,7 +201,7 @@ def partition_metrics(
         outfile=None,
         val_sites=None,
         test_sites=None,
-
+        train_sites=None,
 ):
     """
     calculate metrics for a certain group (or no group at all) for a given
@@ -222,8 +222,9 @@ def partition_metrics(
     names and dict values are the id values. These are added as columns to the
     metrics information
     :param outfile: [str] file where the metrics should be written
-    :param val_sites: [list] sites to exclude from training metrics
+    :param val_sites: [list] sites to exclude from training and test metrics
     :param test_sites: [list] sites to exclude from validation and training metrics
+    :param train_sites: [list] sites to exclude from test metrics
     :return: [pd dataframe] the condensed metrics
     """
     var_data = fmt_preds_obs(preds, obs_file, spatial_idx_name,
@@ -240,6 +241,10 @@ def partition_metrics(
         # mask out test sites from val partition
         if test_sites and partition=='val':
             data = data[~data[spatial_idx_name].isin(test_sites)]
+        if train_sites and partition=='tst':
+            data = data[~data[spatial_idx_name].isin(train_sites)]
+        if val_sites and partition=='tst':
+            data = data[~data[spatial_idx_name].isin(val_sites)]
 
         if not group:
             metrics = calc_metrics(data)

--- a/river_dl/evaluate.py
+++ b/river_dl/evaluate.py
@@ -291,6 +291,7 @@ def combined_metrics(
     pred_tst=None,
     val_sites=None,
     test_sites=None,
+    train_sites=None,
     spatial_idx_name="seg_id_nat",
     time_idx_name="date",
     group=None,
@@ -354,7 +355,8 @@ def combined_metrics(
                                     id_dict=id_dict,
                                     group=group,
                                     val_sites = val_sites,
-                                    test_sites = test_sites)
+                                    test_sites = test_sites,
+                                    train_sites=train_sites)
         df_all.extend([metrics])
 
     df_all = pd.concat(df_all, axis=0)

--- a/river_dl/predict.py
+++ b/river_dl/predict.py
@@ -130,15 +130,16 @@ def predict(
     :return: out predictions
     """
     num_segs = len(np.unique(pred_ids))
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
     if issubclass(type(model), torch.nn.Module):
         if len(x_data.shape) > 3: #Catch for dealing with different GraphWaveNet vs RGCN output, consider changing to bool argument
-            y_pred = predict_torch(x_data, model, batch_size=5)
-            y_pred=y_pred.transpose(1,3)
+            y_pred = predict_torch(x_data.to(device), model, batch_size=5)
+            y_pred=y_pred.transpose(1,3).detach().cpu()
             pred_ids = np.transpose(pred_ids,(0,3,2,1))
             pred_dates=np.transpose(pred_dates,(0,3,2,1))
         else:
-            y_pred = predict_torch(x_data, model, batch_size=num_segs)
+            y_pred = predict_torch(x_data.to(device), model, batch_size=num_segs).detach().cpu()
     elif issubclass(type(model), tf.keras.Model):
         y_pred = model.predict(x_data, batch_size=num_segs)
     else:

--- a/river_dl/predict.py
+++ b/river_dl/predict.py
@@ -130,16 +130,15 @@ def predict(
     :return: out predictions
     """
     num_segs = len(np.unique(pred_ids))
-    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
     if issubclass(type(model), torch.nn.Module):
         if len(x_data.shape) > 3: #Catch for dealing with different GraphWaveNet vs RGCN output, consider changing to bool argument
-            y_pred = predict_torch(x_data.to(device), model, batch_size=5)
-            y_pred=y_pred.transpose(1,3).detach().cpu()
+            y_pred = predict_torch(x_data, model, batch_size=5)
+            y_pred=y_pred.transpose(1,3)
             pred_ids = np.transpose(pred_ids,(0,3,2,1))
             pred_dates=np.transpose(pred_dates,(0,3,2,1))
         else:
-            y_pred = predict_torch(x_data.to(device), model, batch_size=num_segs).detach().cpu()
+            y_pred = predict_torch(x_data, model, batch_size=num_segs)
     elif issubclass(type(model), tf.keras.Model):
         y_pred = model.predict(x_data, batch_size=num_segs)
     else:

--- a/river_dl/torch_utils.py
+++ b/river_dl/torch_utils.py
@@ -244,13 +244,12 @@ def predict_torch(x_data, model, batch_size):
         data.append(torch.from_numpy(x_data[i]).float())
 
     dataloader = torch.utils.data.DataLoader(data, batch_size=batch_size, shuffle=False, pin_memory=True)
-    model.to(device)
     model.eval()
     predicted = []
     for iter, x in enumerate(dataloader):
         trainx = x.to(device)
         with torch.no_grad():
-            output = model(trainx.to(device)).cpu()
+            output = model(trainx).detach().cpu()
         predicted.append(output)
     predicted = torch.cat(predicted, dim=0)
     return predicted

--- a/river_dl/torch_utils.py
+++ b/river_dl/torch_utils.py
@@ -238,7 +238,9 @@ def predict_torch(x_data, model, batch_size):
     @param device: [str] cuda or cpu
     @return: [tensor] predicted values
     """
-    device = next(model.parameters()).device
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    
+    model.to(device)
     data = []
     for i in range(len(x_data)):
         data.append(torch.from_numpy(x_data[i]).float())


### PR DESCRIPTION
This PR adds the capability to remove specific training sites from your testing metrics in the case that train and test periods have overlapping years but distinct sites.   Also changed on how the device in determined in `predict_torch`.  In the previous implementation, it pulled the device based on the model parameters, but since model parameters can be spread across multiple devices it was ambiguous.  