### PR TITLE
adds a function for making composite models

### DIFF
--- a/river_dl/postproc_utils.py
+++ b/river_dl/postproc_utils.py
@@ -197,7 +197,7 @@ each model (range of 0 - 1). If None, the models are weighted equally
             for thisVar in pred_vars:
                 compositeDF[thisVar]=compositeDF[thisVar].values*tempDF.modelWeight.values
             #save the weights for this model to ensure they are 1 across all models    
-            weightCheckDF = deepcopy(tempDF.iloc[:,[0,1,-1]])
+            weightCheckDF = deepcopy(tempDF[[spatial_idx_name, time_idx_name,'modelWeight']])
         else:
             for thisVar in pred_vars:
                 compositeDF[thisVar]=compositeDF[thisVar].values+tempDF[thisVar]*tempDF.modelWeight.values

--- a/river_dl/postproc_utils.py
+++ b/river_dl/postproc_utils.py
@@ -165,7 +165,7 @@ def prepped_array_to_df(data_array, dates, ids, col_names, spatial_idx_name='seg
     return df
 
 
-def combine_preds(fileList,weights=None,pred_vars=["temp_c"], outFile = "composite.feather"):
+def combine_preds(fileList,weights=None,pred_vars=None, outFile = "composite.feather"):
     """
     combine multiple model outputs into 1 composite file
     :param fileList: [str] list of model prediction files
@@ -178,6 +178,8 @@ each model (range of 0 - 1). If None, the models are weighted equally
     for i in range(len(fileList)):
         thisFile = fileList[i]
         tempDF = pd.read_feather(thisFile)
+        if not pred_vars:
+            pred_vars = [x for x in tempDF.columns[2:]]
         if weights:
             thisWeight = weights[i]
             if type(thisWeight)==pd.DataFrame:
@@ -187,7 +189,7 @@ each model (range of 0 - 1). If None, the models are weighted equally
         else:
             tempDF['modelWeight']=1.0/len(fileList)
         
-        #
+        #make the composite dataframe
         if thisFile==fileList[0]:
             compositeDF = tempDF.iloc[:,:-1]
             for thisVar in pred_vars:

--- a/river_dl/postproc_utils.py
+++ b/river_dl/postproc_utils.py
@@ -175,12 +175,13 @@ each model (range of 0 - 1). If None, the models are weighted equally
     :param pred_vars: [str] list of predicted variables
     :param outFile: [str] feather file where the composite predictions should be written
     """
-    for thisFile in fileList:
+    for i in range(len(fileList)):
+        thisFile = fileList[i]
         tempDF = pd.read_feather(thisFile)
         if weights:
-            thisWeight = weights[fileList.index(thisFile)]
+            thisWeight = weights[i]
             if type(thisWeight)==pd.DataFrame:
-                tempDF=tempDF.merge(weightDF)
+                tempDF=tempDF.merge(thisWeight)
             else:
                 tempDF['modelWeight']=float(thisWeight)
         else:

--- a/river_dl/postproc_utils.py
+++ b/river_dl/postproc_utils.py
@@ -204,6 +204,10 @@ each model (range of 0 - 1). If None, the models are weighted equally
             
     #check that all cummulative weights are less than 1.01
     np.testing.assert_allclose(weightCheckDF.modelWeight, 1, rtol=1e-02, atol=1e-02, equal_nan=True, err_msg='Model weights did not sum to 1', verbose=True)
-    
+
+    #drop predicted variables that weren't merged
+    colsToDrop = [x for x in compositeDF.columns[2:] if x not in pred_vars]
+    if len(colsToDrop)>0:
+        compositeDF.drop(columns=colsToDrop,inplace=True)    
     #save the output
     compositeDF.to_feather(outFile)


### PR DESCRIPTION
This PR adds a function for combining predictions from multiple models. This can be used for averaging predictions across multiple runs of the same model or for combining outputs from models with different structures / training data / etc. 

The inputs are a list of prediction files to merge, weights (optional), predicted variables (optional) and an output file for the composite predictions. Weights can be left blank (in which case the prediction files are weighted equally); specified as a list of weights, 1 for each model; or specified as a list of dataframes, 1 for each model, that has columns with the "modelWeight" (0 to 1) and the space and/or time indices to which the weights apply. The function requires that the weights sum to 1 +/- 0.01.

The function assumes that all prediction files are the same shape and that the first 2 columns are space / time and the remaining columns are predicted variables. The default behavior is to merge all predicted variables, but this can be overridden by specifying the predicted variables to merge. (in which case other predicted variables are dropped from the composite prediction file)