### PR TITLE
Drop exclude_file parameters and functions

### DIFF
--- a/workflow_examples/Snakefile_basic.smk
+++ b/workflow_examples/Snakefile_basic.smk
@@ -49,7 +49,6 @@ rule prep_io_data:
                   spatial_idx_name='segs_test',
                   time_idx_name='times_test',
                   catch_prop_file=None,
-                  exclude_file=None,
                   train_start_date=config['train_start_date'],
                   train_end_date=config['train_end_date'],
                   val_start_date=config['val_start_date'],

--- a/workflow_examples/Snakefile_gwn.smk
+++ b/workflow_examples/Snakefile_gwn.smk
@@ -61,7 +61,6 @@ rule prep_io_data:
             y_vars_pretrain=config['y_vars_pretrain'],
             y_vars_finetune=config['y_vars_finetune'],
             catch_prop_file=None,
-            exclude_file=None,
             train_start_date=config['train_start_date'],
             train_end_date=config['train_end_date'],
             val_start_date=config['val_start_date'],

--- a/workflow_examples/Snakefile_pretrain_LSTM.smk
+++ b/workflow_examples/Snakefile_pretrain_LSTM.smk
@@ -54,7 +54,6 @@ rule prep_io_data:
                   spatial_idx_name='segs_test',
                   time_idx_name='times_test',
                   catch_prop_file=None,
-                  exclude_file=None,
                   train_start_date=config['train_start_date'],
                   train_end_date=config['train_end_date'],
                   val_start_date=config['val_start_date'],

--- a/workflow_examples/Snakefile_rgcn.smk
+++ b/workflow_examples/Snakefile_rgcn.smk
@@ -63,7 +63,6 @@ rule prep_io_data:
                   y_vars_pretrain=config['y_vars_pretrain'],
                   y_vars_finetune=config['y_vars_finetune'],
                   catch_prop_file=None,
-                  exclude_file=None,
                   train_start_date=config['train_start_date'],
                   train_end_date=config['train_end_date'],
                   val_start_date=config['val_start_date'],

--- a/workflow_examples/Snakefile_rgcn_hypertune.smk
+++ b/workflow_examples/Snakefile_rgcn_hypertune.smk
@@ -67,7 +67,6 @@ rule prep_io_data:
             y_vars_pretrain=config['y_vars_pretrain'],
             y_vars_finetune=config['y_vars_finetune'],
             catch_prop_file=None,
-            exclude_file=None,
             train_start_date=config['train_start_date'],
             train_end_date=config['train_end_date'],
             val_start_date=config['val_start_date'],

--- a/workflow_examples/Snakefile_rgcn_pytorch.smk
+++ b/workflow_examples/Snakefile_rgcn_pytorch.smk
@@ -61,7 +61,6 @@ rule prep_io_data:
                   y_vars_pretrain=config['y_vars_pretrain'],
                   y_vars_finetune=config['y_vars_finetune'],
                   catch_prop_file=None,
-                  exclude_file=None,
                   train_start_date=config['train_start_date'],
                   train_end_date=config['train_end_date'],
                   val_start_date=config['val_start_date'],


### PR DESCRIPTION
This PR follows up on #98. Currently the code and example Snakemake files suggest that there is an option to specify a file of excluded segments, but the exclusion doesn't get propogated through the code / training (weights are set to 0 for excluded segments but the weights are not currently used in the training => excluding the segments does not actually exclude them). This PR removes the illusion of being able to specify an exclude file.