### PR TITLE
Edits to spatial train/val/test, additional performance metrics

### DIFF
--- a/river_dl/evaluate.py
+++ b/river_dl/evaluate.py
@@ -60,7 +60,7 @@ def rmse_logged(y_true, y_pred):
     """
     y_true, y_pred = filter_nan_preds(y_true, y_pred)
     y_true, y_pred = filter_negative_preds(y_true, y_pred)
-    return rmse_eval(np.log(y_true), np.log(y_pred))
+    return rmse_eval(np.log(y_true + 1e-6), np.log(y_pred + 1e-6))
 
 
 def nse_logged(y_true, y_pred):
@@ -72,7 +72,7 @@ def nse_logged(y_true, y_pred):
     """
     y_true, y_pred = filter_nan_preds(y_true, y_pred)
     y_true, y_pred = filter_negative_preds(y_true, y_pred)
-    return nse_eval(np.log(y_true), np.log(y_pred))
+    return nse_eval(np.log(y_true + 1e-6), np.log(y_pred + 1e-6))
 
 
 def kge_eval(y_true, y_pred):
@@ -102,7 +102,7 @@ def kge_logged(y_true, y_pred):
     """
     y_true, y_pred = filter_nan_preds(y_true, y_pred)
     y_true, y_pred = filter_negative_preds(y_true, y_pred)
-    return kge_eval(np.log(y_true), np.log(y_pred))
+    return kge_eval(np.log(y_true + 1e-6), np.log(y_pred + 1e-6))
 
 def filter_by_percentile(y_true, y_pred, percentile, less_than=True):
     """

--- a/river_dl/evaluate.py
+++ b/river_dl/evaluate.py
@@ -359,6 +359,21 @@ def partition_metrics(
             )
             metrics = calc_metrics(data_calc)
             metrics = pd.DataFrame(metrics).T
+        elif group == ["seg_id_nat", "biweekly"]:
+            #filter the data to remove nans before computing the sum
+            #so that the same days are being summed in the year.
+            data_calc = (data_multiind.dropna()
+            .groupby(
+            [pd.Grouper(level=time_idx_name, freq='2W'),
+             pd.Grouper(level=spatial_idx_name)])
+            .sum()
+            )
+            data_calc = data_calc.reset_index()
+            metrics = (data_calc
+            .groupby(spatial_idx_name)
+            .apply(calc_metrics)
+            .reset_index()
+            )
         elif group == "monthly":
             #filter the data to remove nans before computing the sum
             #so that the same days are being summed in the month.
@@ -370,6 +385,21 @@ def partition_metrics(
             )
             metrics = calc_metrics(data_calc)
             metrics = pd.DataFrame(metrics).T
+        elif group == ["seg_id_nat", "monthly"]:
+            #filter the data to remove nans before computing the sum
+            #so that the same days are being summed in the year.
+            data_calc = (data_multiind.dropna()
+            .groupby(
+            [pd.Grouper(level=time_idx_name, freq='M'),
+             pd.Grouper(level=spatial_idx_name)])
+            .sum()
+            )
+            data_calc = data_calc.reset_index()
+            metrics = (data_calc
+            .groupby(spatial_idx_name)
+            .apply(calc_metrics)
+            .reset_index()
+            )
         elif group == "yearly":
             #filter the data to remove nans before computing the sum
             #so that the same days are being summed in the year.
@@ -381,6 +411,21 @@ def partition_metrics(
             )
             metrics = calc_metrics(data_calc)
             metrics = pd.DataFrame(metrics).T
+        elif group == ["seg_id_nat", "yearly"]:
+            #filter the data to remove nans before computing the sum
+            #so that the same days are being summed in the year.
+            data_calc = (data_multiind.dropna()
+            .groupby(
+            [pd.Grouper(level=time_idx_name, freq='Y'),
+             pd.Grouper(level=spatial_idx_name)])
+            .sum()
+            )
+            data_calc = data_calc.reset_index()
+            metrics = (data_calc
+            .groupby(spatial_idx_name)
+            .apply(calc_metrics)
+            .reset_index()
+            )
         else:
             raise ValueError("group value not valid")
 
@@ -434,7 +479,17 @@ def combined_metrics(
     :param group: [str or list] which group the metrics should be computed for.
     Currently only supports 'seg_id_nat' (segment-wise metrics), 'month'
     (month-wise metrics), ['seg_id_nat', 'month'] (metrics broken out by segment
-    and month), and None (everything is left together)
+    and month), 'year' (year-wise metrics), ['seg_id_nat', 'year'] 
+    (metrics broken out by segment and year), 'biweekly' (metrics for 
+    biweekly timeseries, aggregated by summing data in the original timestep)
+    'monthly' (metrics for monthly timeseries, aggregated by summing data 
+    in the original timestep), 'yearly' (metrics for yearly timeseries, 
+    aggregated by summing data in the original timestep), 
+    ["seg_id_nat", "biweekly"] (metrics for biweekly timeseries broken out 
+    by segment), ["seg_id_nat", "monthly"] (metrics for monthly timeseries broken out 
+    by segment), ["seg_id_nat", "yearly"] (metrics for yearly timeseries 
+    broken out by segment), and None (metrics in the original timestep computed 
+    across all space)
     :param id_dict: [dict] dictionary of id_dict where dict keys are the id
     names and dict values are the id values. These are added as columns to the
     metrics information

--- a/river_dl/evaluate.py
+++ b/river_dl/evaluate.py
@@ -238,7 +238,7 @@ def partition_metrics(
     :param outfile: [str] file where the metrics should be written
     :param val_sites: [list] sites to exclude from training and test metrics
     :param test_sites: [list] sites to exclude from validation and training metrics
-    :param train_sites: [list] sites to exclude from test metrics
+    :param train_sites: [list] sites to exclude from validation and test metrics
     :return: [pd dataframe] the condensed metrics
     """
     var_data = fmt_preds_obs(preds, obs_file, spatial_idx_name,
@@ -255,6 +255,8 @@ def partition_metrics(
         # mask out test sites from val partition
         if test_sites and partition=='val':
             data = data[~data[spatial_idx_name].isin(test_sites)]
+        if train_sites and partition=='val':
+            data = data[~data[spatial_idx_name].isin(train_sites)]
         if train_sites and partition=='tst':
             data = data[~data[spatial_idx_name].isin(train_sites)]
         if val_sites and partition=='tst':

--- a/river_dl/evaluate.py
+++ b/river_dl/evaluate.py
@@ -364,8 +364,8 @@ def partition_metrics(
                 if group_temporally != 'M':
                     #native timestep performance metrics within the group_temporally groups
                     #This method will report one row per group_temporally group
-                    # examples: year-month would be a group when group_temporally is 'M'
-                    # year is a group when group_temporally is 'Y'
+                    # examples: year-month-week would be a group when group_temporally is 'W'
+                    # year would be a group when group_temporally is 'Y'
                     metrics = (data
                     .groupby(pd.Grouper(level=time_idx_name, freq=group_temporally))
                     .apply(calc_metrics)

--- a/river_dl/evaluate.py
+++ b/river_dl/evaluate.py
@@ -248,19 +248,31 @@ def partition_metrics(
     for data_var, data in var_data.items():
         data.reset_index(inplace=True)
         # mask out validation and test sites from trn partition
-        if val_sites and partition == 'trn':
-            data = data[~data[spatial_idx_name].isin(val_sites)]
-        if test_sites and partition == 'trn':
-            data = data[~data[spatial_idx_name].isin(test_sites)]
-        # mask out test sites from val partition
-        if test_sites and partition=='val':
-            data = data[~data[spatial_idx_name].isin(test_sites)]
-        if train_sites and partition=='val':
-            data = data[~data[spatial_idx_name].isin(train_sites)]
-        if train_sites and partition=='tst':
-            data = data[~data[spatial_idx_name].isin(train_sites)]
-        if val_sites and partition=='tst':
-            data = data[~data[spatial_idx_name].isin(val_sites)]
+        if train_sites and partition == 'trn':
+            # simply use the train sites when specified.
+            data = data[data[spatial_idx_name].isin(train_sites)]
+        else:
+            #check if validation or testing sites are specified
+            if val_sites and partition == 'trn':
+                data = data[~data[spatial_idx_name].isin(val_sites)]
+            if test_sites and partition == 'trn':
+                data = data[~data[spatial_idx_name].isin(test_sites)]
+        # mask out training and test sites from val partition
+        if val_sites and partition == 'val':
+            data = data[data[spatial_idx_name].isin(val_sites)]
+        else:
+            if test_sites and partition=='val':
+                data = data[~data[spatial_idx_name].isin(test_sites)]
+            if train_sites and partition=='val':
+                data = data[~data[spatial_idx_name].isin(train_sites)]
+        # mask out training and validation sites from val partition
+        if test_sites and partition == 'tst':
+            data = data[data[spatial_idx_name].isin(tst_sites)]
+        else:
+            if train_sites and partition=='tst':
+                data = data[~data[spatial_idx_name].isin(train_sites)]
+            if val_sites and partition=='tst':
+                data = data[~data[spatial_idx_name].isin(val_sites)]
 
         if not group:
             metrics = calc_metrics(data)

--- a/river_dl/evaluate.py
+++ b/river_dl/evaluate.py
@@ -213,7 +213,7 @@ def partition_metrics(
         time_idx_name="date",
         group_spatially=False,
         group_temporally=False,
-        sum_aggregation=False,
+        time_aggregation=False,
         site_based=False,
         id_dict=None,
         outfile=None,
@@ -237,21 +237,21 @@ def partition_metrics(
     the native timestep of the data. When a str, the str is passed to pd.Grouper
     freq to group the data within the specified timestep 
     (e.g., 'W', 'M', 'Y' for week, month, and year)
-    :param sum_aggregation [bool] Only applies when group_temporally is a string.
-    when sum_aggregation is True, metrics are computed by first summing data 
+    :param time_aggregation [bool] Only applies when group_temporally is a string.
+    when time_aggregation is True, metrics are computed by first averaging data 
     from the native timestep to the group_temporally timestep. Only native timesteps
-    with observations are summed. When False, metrics are computed for the 
+    with observations are averaged. When False, metrics are computed for the 
     native timestep of the data within the group_temporally groups (e.g., 
     for daily data and group_temporally = 'Y', all days with observations
     in the calendar year are used to compute a metric for that year). Note that
     for month, 'M', this would normally have groups by year-month. We have forced
     the groups to the 12 calendar months instead.
     :param site_based [bool] Only applies when group_spatially is False,
-    group_temporally is a string, and sum_aggregation is True. When
-    site_based is True, the sum is computed for each site to get a 
+    group_temporally is a string, and time_aggregation is True. When
+    site_based is True, the average is computed for each site to get a 
     group_temporally timeseries for each site. When False, the
-    sum is computed over all sites to get a group_temporally timeseries 
-    using data from all reaches in each day.
+    average is computed over all sites to get a group_temporally timeseries 
+    using data from all reaches.
     :param id_dict: [dict] dictionary of id_dict where dict keys are the id
     names and dict values are the id values. These are added as columns to the
     metrics information
@@ -323,9 +323,9 @@ def partition_metrics(
             .reset_index()
             )
         elif not group_spatially and group_temporally:
-            if sum_aggregation:
+            if time_aggregation:
                 #performance metrics computed at the group_temporally timestep
-                #for some reason, no `.` calculations are allowed after .sum(),
+                #for some reason, no `.` calculations are allowed after .mean(),
                 #so calc_metrics() is called first.
                 if site_based:
                     #create a group_temporally timeseries for each observation site
@@ -335,14 +335,14 @@ def partition_metrics(
                     .dropna()
                     .groupby([pd.Grouper(level=time_idx_name, freq=group_temporally),
                              pd.Grouper(level=spatial_idx_name)])
-                    .sum()
+                    .mean()
                     )
                 else:
                     #create a group_temporally timeseries using data from all reaches
                     data_sum = (data
                     .dropna()
                     .groupby(pd.Grouper(level=time_idx_name, freq=group_temporally))
-                    .sum()
+                    .mean()
                     )
                     #For some reason, with pd.Grouper the sum is computed as 0
                     # on days with no observations. Need to remove these days
@@ -379,15 +379,15 @@ def partition_metrics(
                     .reset_index()
                     )                
         elif group_spatially and group_temporally:
-            if sum_aggregation:
+            if time_aggregation:
                 #performance metrics for each reach computed at the group_temporally timestep
                 data_calc = (data
                 .dropna()
                 .groupby([pd.Grouper(level=time_idx_name, freq=group_temporally),
                           pd.Grouper(level=spatial_idx_name)])
-                .sum()
+                .mean()
                 )
-                #unable to apply any other . functions after .sum().
+                #unable to apply any other . functions after .mean().
                 metrics = (data_calc.groupby(pd.Grouper(level=spatial_idx_name))
                 .apply(calc_metrics)
                 .reset_index()
@@ -432,7 +432,7 @@ def combined_metrics(
     time_idx_name="date",
     group_spatially=False,
     group_temporally=False,
-    sum_aggregation=False,
+    time_aggregation=False,
     site_based=False,
     id_dict=None,
     outfile=None,
@@ -462,21 +462,21 @@ def combined_metrics(
     the native timestep of the data. When a str, the str is passed to pd.Grouper
     freq to group the data within the specified timestep 
     (e.g., 'W', 'M', 'Y' for week, month, and year)
-    :param sum_aggregation [bool] Only applies when group_temporally is a string.
-    when sum_aggregation is True, metrics are computed by first summing data 
+    :param time_aggregation [bool] Only applies when group_temporally is a string.
+    when time_aggregation is True, metrics are computed by first averaging data 
     from the native timestep to the group_temporally timestep. Only native timesteps
-    with observations are summed. When False, metrics are computed for the 
+    with observations are averaged. When False, metrics are computed for the 
     native timestep of the data within the group_temporally groups (e.g., 
     for daily data and group_temporally = 'Y', all days with observations
     in the calendar year are used to compute a metric for that year). Note that
     for month, 'M', this would normally have groups by year-month. We have forced
     the groups to the 12 calendar months instead.
     :param site_based [bool] Only applies when group_spatially is False,
-    group_temporally is a string, and sum_aggregation is True. When
-    site_based is True, the sum is computed for each site to get a 
+    group_temporally is a string, and time_aggregation is True. When
+    site_based is True, the average is computed for each site to get a 
     group_temporally timeseries for each site. When False, the
-    sum is computed over all sites to get a group_temporally timeseries 
-    using data from all reaches in each day.
+    average is computed over all sites to get a group_temporally timeseries 
+    using data from all reaches.
     :param id_dict: [dict] dictionary of id_dict where dict keys are the id
     names and dict values are the id values. These are added as columns to the
     metrics information
@@ -510,7 +510,7 @@ def combined_metrics(
                                     id_dict=id_dict,
                                     group_spatially=group_spatially,
                                     group_temporally=group_temporally,
-                                    sum_aggregation=sum_aggregation,
+                                    time_aggregation=time_aggregation,
                                     site_based=site_based,
                                     val_sites = val_sites,
                                     test_sites = test_sites,

--- a/river_dl/evaluate.py
+++ b/river_dl/evaluate.py
@@ -339,7 +339,7 @@ def partition_metrics(
                     )
                 else:
                     #create a group_temporally timeseries using data from all reaches
-                    data_sum = (data
+                    data_mean = (data
                     .dropna()
                     .groupby(pd.Grouper(level=time_idx_name, freq=group_temporally))
                     .mean()
@@ -357,8 +357,8 @@ def partition_metrics(
                     .obs == 0
                     )[0]
                     if len(data_count_0) > 0:
-                        data_sum = data_sum.drop(index=data_sum.index[data_count_0])
-                    metrics = calc_metrics(data_sum)
+                        data_mean = data_mean.drop(index=data_mean.index[data_count_0])
+                    metrics = calc_metrics(data_mean)
                 metrics = pd.DataFrame(metrics).T
             else:
                 if group_temporally != 'M':

--- a/river_dl/evaluate.py
+++ b/river_dl/evaluate.py
@@ -180,7 +180,8 @@ def calc_metrics(df):
             "kge": kge_eval(obs, pred),
             "kge_logged": kge_logged(obs, pred),
             "kge_top10": percentile_metric(obs, pred, kge_eval, 90, less_than=False),
-            "kge_bot10": percentile_metric(obs, pred, kge_eval, 10, less_than=True)
+            "kge_bot10": percentile_metric(obs, pred, kge_eval, 10, less_than=True),
+            "n_obs": len(obs)
         }
     else:
         metrics = {
@@ -198,7 +199,8 @@ def calc_metrics(df):
             "kge": np.nan,
             "kge_logged": np.nan,
             "kge_top10": np.nan,
-            "kge_bot10": np.nan
+            "kge_bot10": np.nan,
+            "n_obs": len(obs)
         }
     return pd.Series(metrics)
 

--- a/river_dl/evaluate.py
+++ b/river_dl/evaluate.py
@@ -152,7 +152,7 @@ def calc_metrics(df):
     pred = df["pred"].values
     obs, pred = filter_nan_preds(obs, pred)
 
-    if len(obs) > 20:
+    if len(obs) > 10:
         metrics = {
             "rmse": rmse_eval(obs, pred),
             "nse": nse_eval(obs, pred),

--- a/river_dl/evaluate.py
+++ b/river_dl/evaluate.py
@@ -249,9 +249,12 @@ def partition_metrics(
     :param site_based [bool] Only applies when group_spatially is False,
     group_temporally is a string, and time_aggregation is True. When
     site_based is True, the average is computed for each site to get a 
-    group_temporally timeseries for each site. When False, the
-    average is computed over all sites to get a group_temporally timeseries 
-    using data from all reaches.
+    group_temporally timeseries for each site. The observations used in the 
+    calculation are each group_temporally timestep for each reach with observations 
+    (max obs length of n_segs*n_timesteps). When False, the average is computed over all sites 
+    to get a group_temporally timeseries using data from all reaches. The observations 
+    used in the calculation are each group_temporally timestep with observations 
+    (max obs length of n_timesteps).
     :param id_dict: [dict] dictionary of id_dict where dict keys are the id
     names and dict values are the id values. These are added as columns to the
     metrics information
@@ -474,9 +477,12 @@ def combined_metrics(
     :param site_based [bool] Only applies when group_spatially is False,
     group_temporally is a string, and time_aggregation is True. When
     site_based is True, the average is computed for each site to get a 
-    group_temporally timeseries for each site. When False, the
-    average is computed over all sites to get a group_temporally timeseries 
-    using data from all reaches.
+    group_temporally timeseries for each site. The observations used in the 
+    calculation are each group_temporally timestep for each reach with observations 
+    (max obs length of n_segs*n_timesteps). When False, the average is computed over all sites 
+    to get a group_temporally timeseries using data from all reaches. The observations 
+    used in the calculation are each group_temporally timestep with observations 
+    (max obs length of n_timesteps).
     :param id_dict: [dict] dictionary of id_dict where dict keys are the id
     names and dict values are the id values. These are added as columns to the
     metrics information

--- a/river_dl/preproc_utils.py
+++ b/river_dl/preproc_utils.py
@@ -633,7 +633,7 @@ def prep_y_data(
     :param test_end_date: [str or list] fmt: "YYYY-MM-DD"; date(s) to end test
     period (can have multiple discontinuous periods)
     :param val_sites: [list of site_ids] sites to retain for validation. These
-    sites will be witheld from training
+    sites will be witheld from training and testing
     :param test_sites: [list of site_ids] sites to retain for testing. These
     sites will be witheld from training and validation
     :param strict_spatial_partition: [bool] when True, the test set does not 
@@ -678,6 +678,7 @@ def prep_y_data(
     # replace validation sites' (and test sites') data with np.nan
     if val_sites:
         y_trn = y_trn.where(~y_trn[spatial_idx_name].isin(val_sites))
+        y_tst = y_tst.where(~y_tst[spatial_idx_name].isin(val_sites))
         if strict_spatial_partition:
             y_val = y_val.where(y_val[spatial_idx_name].isin(val_sites))
 

--- a/river_dl/preproc_utils.py
+++ b/river_dl/preproc_utils.py
@@ -806,7 +806,8 @@ def prep_all_data(
     latest_time=None,
     normalize_y=True,
     trn_offset = 1.0,
-    tst_val_offset = 1.0
+    tst_val_offset = 1.0,
+    check_pre_partitions=True
 ):
     """
     prepare input and output data for DL model training read in and process
@@ -871,6 +872,8 @@ def prep_all_data(
     :param out_file: [str] file to where the values will be written
     :param trn_offset: [str] value for the training offset
     :param tst_val_offset: [str] value for the testing and validation offset
+    :param check_pre_partitions [bool] when True, pretarining partitions are
+    checked for unique data in each partition.
     :returns: training and testing data along with the means and standard
     deviations of the training input and output data
             "x_trn": x training data
@@ -1092,8 +1095,9 @@ def prep_all_data(
                 trn_offset = trn_offset,
                 tst_val_offset = tst_val_offset
             )
-            #check that the trn, val, and tst partitions have unique data
-            check_partitions(x_data_dict, y_pre_data, pre = True)
+            if check_pre_partitions:
+                #check that the trn, val, and tst partitions have unique data
+                check_partitions(x_data_dict, y_pre_data, pre = True)
         
     # if there is no observation file, use the pretrain mean and standard dev
     # to do the scaling/centering
@@ -1118,8 +1122,9 @@ def prep_all_data(
             trn_offset = trn_offset,
             tst_val_offset = tst_val_offset
         )
-        #check that the trn, val, and tst partitions have unique data
-        check_partitions(x_data_dict, y_pre_data, pre = True)
+        if check_pre_partitions:
+            #check that the trn, val, and tst partitions have unique data
+            check_partitions(x_data_dict, y_pre_data, pre = True)
     else:
         raise Warning("No y_dataset data was provided")
     

--- a/river_dl/preproc_utils.py
+++ b/river_dl/preproc_utils.py
@@ -596,6 +596,7 @@ def prep_y_data(
     test_end_date=None,
     val_sites=None,
     test_sites=None,
+    strict_spatial_partition=False,
     spatial_idx_name="seg_id_nat",
     time_idx_name="date",
     seq_len=365,
@@ -635,6 +636,9 @@ def prep_y_data(
     sites will be witheld from training
     :param test_sites: [list of site_ids] sites to retain for testing. These
     sites will be witheld from training and validation
+    :param strict_spatial_partition: [bool] when True, the test set does not 
+    contain any reaches that are used in training or validation, and the
+    validation set does not contain any reaches that are used in training or testing.
     :param seq_len: [int] length of sequences (e.g., 365)
     :param log_vars: [list-like] which variables_to_log (if any) to take log of
     :param exclude_file: [str] path to exclude file
@@ -674,10 +678,14 @@ def prep_y_data(
     # replace validation sites' (and test sites') data with np.nan
     if val_sites:
         y_trn = y_trn.where(~y_trn[spatial_idx_name].isin(val_sites))
+        if strict_spatial_partition:
+            y_val = y_val.where(y_val[spatial_idx_name].isin(val_sites))
 
     if test_sites:
         y_trn = y_trn.where(~y_trn[spatial_idx_name].isin(test_sites))
         y_val = y_val.where(~y_val[spatial_idx_name].isin(test_sites))
+        if strict_spatial_partition:
+            y_tst = y_tst.where(y_tst[spatial_idx_name].isin(test_sites))
 
 
     if log_vars:
@@ -757,6 +765,7 @@ def prep_all_data(
     test_end_date=None,
     val_sites=None,
     test_sites=None,
+    strict_spatial_partition=False,
     y_vars_finetune=None,
     y_vars_pretrain=None,
     spatial_idx_name="seg_id_nat",
@@ -806,6 +815,9 @@ def prep_all_data(
     sites will be witheld from training
     :param test_sites: [list of site_ids] sites to retain for testing. These
     sites will be witheld from training and validation
+    :param strict_spatial_partition: [bool] when True, the test set does not 
+    contain any reaches that are used in training or validation, and the
+    validation set does not contain any reaches that are used in training or testing.
     :param spatial_idx_name: [str] name of column that is used for spatial
     index (e.g., 'seg_id_nat')
     :param time_idx_name: [str] name of column that is used for temporal index
@@ -1017,6 +1029,7 @@ def prep_all_data(
             test_end_date=test_end_date,
             val_sites=val_sites,
             test_sites=test_sites,
+            strict_spatial_partition=strict_spatial_partition,
             spatial_idx_name=spatial_idx_name,
             time_idx_name=time_idx_name,
             seq_len=seq_len,

--- a/river_dl/preproc_utils.py
+++ b/river_dl/preproc_utils.py
@@ -638,9 +638,9 @@ def prep_y_data(
     :param test_sites: [list of site_ids] all sites for the testing partition.
     :param explicit_spatial_partition: [bool] when True and train_sites 
     (val_sites, test_sites) is specified, the train_sites (val_sites, tst_sites)
-    are removed from the other partitions. When False and train_sites 
-    (val_sites, test_sites) is specified, the train_sites (val_sites, tst_sites)
-    may appear in other partitions.
+    are removed from the other partitions, unless sites are provided for those 
+    partitions. When False and train_sites (val_sites, test_sites) is specified, 
+    the train_sites (val_sites, tst_sites) may appear in other partitions.
     :param seq_len: [int] length of sequences (e.g., 365)
     :param log_vars: [list-like] which variables_to_log (if any) to take log of
     :param exclude_file: [str] path to exclude file
@@ -681,23 +681,32 @@ def prep_y_data(
     if train_sites:
         y_trn = y_trn.where(y_trn[spatial_idx_name].isin(train_sites))
         if explicit_spatial_partition:
-            #remove training sites from validation and testing
-            y_val = y_val.where(~y_val[spatial_idx_name].isin(train_sites))
-            y_tst = y_tst.where(~y_tst[spatial_idx_name].isin(train_sites))
+            #remove training sites from validation and testing, unless
+            # sites are provided for those partitions
+            if not val_sites:
+                y_val = y_val.where(~y_val[spatial_idx_name].isin(train_sites))
+            if not test_sites:
+                y_tst = y_tst.where(~y_tst[spatial_idx_name].isin(train_sites))
     
     if val_sites:
         y_val = y_val.where(y_val[spatial_idx_name].isin(val_sites))
         if explicit_spatial_partition:
-            #remove validation sites from training and testing
-            y_trn = y_trn.where(~y_trn[spatial_idx_name].isin(val_sites))
-            y_tst = y_tst.where(~y_tst[spatial_idx_name].isin(val_sites))
+            #remove validation sites from training and testing, unless
+            # sites are provided for those partitions
+            if not train_sites:
+                y_trn = y_trn.where(~y_trn[spatial_idx_name].isin(val_sites))
+            if not test_sites:
+                y_tst = y_tst.where(~y_tst[spatial_idx_name].isin(val_sites))
     
     if test_sites:
         y_tst = y_tst.where(y_tst[spatial_idx_name].isin(test_sites))
         if explicit_spatial_partition:
-            #remove test sites from training and validation
-            y_trn = y_trn.where(~y_trn[spatial_idx_name].isin(test_sites))
-            y_val = y_val.where(~y_val[spatial_idx_name].isin(test_sites))
+            #remove test sites from training and validation, unless
+            # sites are provided for those partitions
+            if not train_sites:
+                y_trn = y_trn.where(~y_trn[spatial_idx_name].isin(test_sites))
+            if not val_sites:
+                y_val = y_val.where(~y_val[spatial_idx_name].isin(test_sites))
 
     if log_vars:
         y_trn = log_variables(y_trn, log_vars)

--- a/river_dl/preproc_utils.py
+++ b/river_dl/preproc_utils.py
@@ -1092,8 +1092,8 @@ def prep_all_data(
                 trn_offset = trn_offset,
                 tst_val_offset = tst_val_offset
             )
-        #check that the trn, val, and tst partitions have unique data
-        check_partitions(x_data_dict, y_pre_data, pre = True)
+            #check that the trn, val, and tst partitions have unique data
+            check_partitions(x_data_dict, y_pre_data, pre = True)
         
     # if there is no observation file, use the pretrain mean and standard dev
     # to do the scaling/centering

--- a/river_dl/preproc_utils.py
+++ b/river_dl/preproc_utils.py
@@ -596,7 +596,7 @@ def prep_y_data(
     test_end_date=None,
     val_sites=None,
     test_sites=None,
-    strict_spatial_partition=False,
+    explicit_spatial_partition=False,
     spatial_idx_name="seg_id_nat",
     time_idx_name="date",
     seq_len=365,
@@ -636,9 +636,11 @@ def prep_y_data(
     sites will be witheld from training and testing
     :param test_sites: [list of site_ids] sites to retain for testing. These
     sites will be witheld from training and validation
-    :param strict_spatial_partition: [bool] when True, the test set does not 
-    contain any reaches that are used in training or validation, and the
-    validation set does not contain any reaches that are used in training or testing.
+    :param explicit_spatial_partition: [bool] when True and val_sites (test_sites)
+    is specified, the validation set (test set) will contain only the val_sites
+    (test_sites). When False and val_sites (test_sites) is specified, 
+    the spatial removal of data from the validation set (test set) will not 
+    remove reaches that are in the training set.
     :param seq_len: [int] length of sequences (e.g., 365)
     :param log_vars: [list-like] which variables_to_log (if any) to take log of
     :param exclude_file: [str] path to exclude file
@@ -679,13 +681,13 @@ def prep_y_data(
     if val_sites:
         y_trn = y_trn.where(~y_trn[spatial_idx_name].isin(val_sites))
         y_tst = y_tst.where(~y_tst[spatial_idx_name].isin(val_sites))
-        if strict_spatial_partition:
+        if explicit_spatial_partition:
             y_val = y_val.where(y_val[spatial_idx_name].isin(val_sites))
 
     if test_sites:
         y_trn = y_trn.where(~y_trn[spatial_idx_name].isin(test_sites))
         y_val = y_val.where(~y_val[spatial_idx_name].isin(test_sites))
-        if strict_spatial_partition:
+        if explicit_spatial_partition:
             y_tst = y_tst.where(y_tst[spatial_idx_name].isin(test_sites))
 
 
@@ -766,7 +768,7 @@ def prep_all_data(
     test_end_date=None,
     val_sites=None,
     test_sites=None,
-    strict_spatial_partition=False,
+    explicit_spatial_partition=False,
     y_vars_finetune=None,
     y_vars_pretrain=None,
     spatial_idx_name="seg_id_nat",
@@ -816,9 +818,11 @@ def prep_all_data(
     sites will be witheld from training
     :param test_sites: [list of site_ids] sites to retain for testing. These
     sites will be witheld from training and validation
-    :param strict_spatial_partition: [bool] when True, the test set does not 
-    contain any reaches that are used in training or validation, and the
-    validation set does not contain any reaches that are used in training or testing.
+    :param explicit_spatial_partition: [bool] when True and val_sites (test_sites) 
+    is specified, the validation set (test set) will contain only the val_sites 
+    (test_sites). When False and val_sites (test_sites) is specified, 
+    the spatial removal of data from the validation set (test set) will not 
+    remove reaches that are in the training set.
     :param spatial_idx_name: [str] name of column that is used for spatial
     index (e.g., 'seg_id_nat')
     :param time_idx_name: [str] name of column that is used for temporal index
@@ -1030,7 +1034,7 @@ def prep_all_data(
             test_end_date=test_end_date,
             val_sites=val_sites,
             test_sites=test_sites,
-            strict_spatial_partition=strict_spatial_partition,
+            explicit_spatial_partition=explicit_spatial_partition,
             spatial_idx_name=spatial_idx_name,
             time_idx_name=time_idx_name,
             seq_len=seq_len,

--- a/river_dl/preproc_utils.py
+++ b/river_dl/preproc_utils.py
@@ -1078,9 +1078,9 @@ def check_partitions(data, y, pre=False):
     times and site ids
     
     :param data: [dict] data dictionary with keys 'ids_<partition>' and 
-    'times_<partition>', where partition = trn, val, and tst.
+    'times_<partition>', where partition = trn, val, and/or tst.
     :param y: [dict] data dictionary with keys 'y_<phase>_<partition>', 
-    where phase is obs or pre, and partition = trn, val, and tst.
+    where phase is obs or pre, and partition = trn, val, and/or tst.
     :param pre: [bool] when True, phase is pre for pretraining. when False,
     phase is obs.
     
@@ -1093,19 +1093,27 @@ def check_partitions(data, y, pre=False):
         phase = 'obs'
     
     #Get site ids and times for train, val, test data into a matrix
-    df_trn = pd.DataFrame({'ids': np.reshape(data['ids_trn'], (-1)),
-                           'times': np.reshape(data['times_trn'], (-1)),
-                           'obs': np.reshape(y['y_'+phase+'_trn'], (-1))})
-    df_val = pd.DataFrame({'ids': np.reshape(data['ids_val'], (-1)),
-                           'times': np.reshape(data['times_val'], (-1)),
-                           'obs': np.reshape(y['y_'+phase+'_val'], (-1))})
-    df_tst = pd.DataFrame({'ids': np.reshape(data['ids_tst'], (-1)),
-                           'times': np.reshape(data['times_tst'], (-1)),
-                           'obs': np.reshape(y['y_'+phase+'_tst'], (-1))})
-    #remove rows with nan observations
-    df_trn.dropna(inplace=True)
-    df_val.dropna(inplace=True)
-    df_tst.dropna(inplace=True)
+    if 'y_'+phase+'_trn' in y.keys():
+        df_trn = pd.DataFrame({'ids': np.reshape(data['ids_trn'], (-1)),
+                               'times': np.reshape(data['times_trn'], (-1)),
+                               'obs': np.reshape(y['y_'+phase+'_trn'], (-1))})
+        df_trn.dropna(inplace=True)
+    else:
+        df_trn = None
+    if 'y_'+phase+'_val' in y.keys():
+        df_val = pd.DataFrame({'ids': np.reshape(data['ids_val'], (-1)),
+                               'times': np.reshape(data['times_val'], (-1)),
+                               'obs': np.reshape(y['y_'+phase+'_val'], (-1))})
+        df_val.dropna(inplace=True)
+    else:
+        df_val = None
+    if 'y_'+phase+'_tst' in y.keys():
+        df_tst = pd.DataFrame({'ids': np.reshape(data['ids_tst'], (-1)),
+                               'times': np.reshape(data['times_tst'], (-1)),
+                               'obs': np.reshape(y['y_'+phase+'_tst'], (-1))})
+        df_tst.dropna(inplace=True)
+    else:
+        df_tst = None
     
     #When the data are aggregated into a single dataframe
     # there should be no duplicated rows


### PR DESCRIPTION
- I found that validation segments were appearing in the test set, and training segments were appearing in validation. I edited some if/else statements to ensure that only test segments are in testing, and only validation are in validation. I'm not sure if the previous implementation was as-intended or a bug.
- I added bi-weekly, monthly, and yearly performance metrics, and a by-year summary of daily data. Also added log-KGE, and recommending that 21 be the minimum number of observations needed to compute a performance metric. For the 10th and 90th percentile metrics, this would give 2 samples each.
- I added args to preprocessing to filter the x_data by an earliest and/or latest date. With these arguments, the xarray of data could contain NAs/NaNs before or after these dates, respectively. I think this is useful when there are lagged attributes that would have NAs in the lag before the 1st non-NA point.